### PR TITLE
Feature/model 1 observers

### DIFF
--- a/src/vivarium_gates_iv_iron/components/__init__.py
+++ b/src/vivarium_gates_iv_iron/components/__init__.py
@@ -1,2 +1,2 @@
-from vivarium_gates_iv_iron.components.observers import MortalityObserver, DisabilityObserver
+from vivarium_gates_iv_iron.components.observers import MortalityObserver, DisabilityObserver, PregnancyObserver
 from vivarium_gates_iv_iron.components.pregnancy import Pregnancy

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -10,6 +10,7 @@ components:
         - Pregnancy()
 #        - DisabilityObserver()
 #        - MortalityObserver()
+        - PregnancyObserver()
 #
 #        #- LowBirthWeight()
 #        #- ShortGestation()
@@ -52,5 +53,5 @@ configuration:
             by_year: True
         pregnancy:
             by_age: True
-            by_sex: True
+            by_sex: False
             by_year: True

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -50,3 +50,7 @@ configuration:
             by_age: True
             by_sex: True
             by_year: True
+        pregnancy:
+            by_age: True
+            by_sex: True
+            by_year: True

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -8,8 +8,8 @@ components:
 
     vivarium_gates_iv_iron.components:
         - Pregnancy()
-#        - DisabilityObserver()
-#        - MortalityObserver()
+        - DisabilityObserver()
+        - MortalityObserver()
         - PregnancyObserver()
 #
 #        #- LowBirthWeight()

--- a/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
@@ -6,8 +6,8 @@ components:
 
     vivarium_gates_iv_iron.components:
         - Pregnancy()
-#        - DisabilityObserver()
-#        - MortalityObserver()
+        - DisabilityObserver()
+        - MortalityObserver()
         - PregnancyObserver()
 
 configuration:

--- a/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
@@ -5,8 +5,10 @@ components:
             - Mortality()
 
     vivarium_gates_iv_iron.components:
-        - DisabilityObserver()
-        - MortalityObserver()
+        - Pregnancy()
+#        - DisabilityObserver()
+#        - MortalityObserver()
+        - PregnancyObserver()
 
 configuration:
     input_data:
@@ -43,4 +45,8 @@ configuration:
         mortality:
             by_age: True
             by_sex: True
+            by_year: True
+        pregnancy:
+            by_age: True
+            by_sex: False
             by_year: True


### PR DESCRIPTION
## Model 1: Pregnancy Observer

### Description
- *Category*: observers
- *JIRA issue*: [MIC-2804](https://jira.ihme.washington.edu/browse/MIC-2804) 
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_iv_iron/maternal_model/concept_model.html#simulation-output-table

Adds a pregnancy observer to collect `conception_count`, pregnancy outcome counts, and pregnancy state person-time.

### Verification and Testing
Ran `simulate` successfully, with conception counts, pregnancy outcome counts, and person time all matching expected values.
