### PR TITLE
Make background mortality rate a pipeline that scales by timestep

### DIFF
--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -62,10 +62,12 @@ class Pregnancy:
             [col for col in metadata.ARTIFACT_INDEX_COLUMNS if col != "location"])
         maternal_disorder_csmr = builder.data.load(data_keys.MATERNAL_DISORDERS.CSMR).set_index(
             [col for col in metadata.ARTIFACT_INDEX_COLUMNS if col != "location"])
-        self.background_mortality_rate = builder.lookup.build_table(
+        background_mortality_rate_table = builder.lookup.build_table(
             (all_cause_mortality_data - maternal_disorder_csmr).reset_index(),
             key_columns=['sex'],
             parameter_columns=['age', 'year'])
+        self.background_mortality_rate = builder.value.register_rate_producer('background_mortality_rate',
+                                                                              source=background_mortality_rate_table)
         maternal_disorder_incidence = builder.data.load(data_keys.MATERNAL_DISORDERS.INCIDENCE_RATE).set_index(
             [col for col in metadata.ARTIFACT_INDEX_COLUMNS if col != "location"])
 


### PR DESCRIPTION
## Mend issue with background mortality being 50x too high

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-2944](https://jira.ihme.washington.edu/browse/MIC-2944)

Changes background mortality from a lookup table to a pipeline that is scaled to the 
timestep.

### Verification and Testing
Results with modified code showed ACMR to be in line with artifact.
Before:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/13937263/159077253-f49c18e2-bbb7-4a50-9210-a46ae20a075f.png">

After: 
<img width="674" alt="image" src="https://user-images.githubusercontent.com/13937263/159077194-c9742022-cf1f-49c5-aa61-0be597e6956c.png">


