### PR TITLE
Change ASFR to use truncated norm, update development dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     # use "pip install -e .[dev]" to install required components + extra components
     extras_require = [
         "vivarium_cluster_tools==1.2.10",
-        "vivarium_inputs[data]==4.0.4",
+        "vivarium_inputs[data]==4.0.6",
     ]
 
     setup(

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     # use "pip install -e .[dev]" to install required components + extra components
     extras_require = [
-        "vivarium_cluster_tools==1.2.10",
+        "vivarium_cluster_tools==1.3.0",
         "vivarium_inputs[data]==4.0.6",
     ]
 

--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -320,7 +320,7 @@ def create_draws(df: pd.DataFrame, key: str, location: str):
     lower = df['lower_value']
     upper = df['upper_value']
 
-    Tuple = (key, get_norm_from_quantiles(mean=mean, lower=lower, upper=upper))
+    Tuple = (key, utilities.get_truncnorm_from_quantiles(mean=mean, lower=lower, upper=upper))
     # pull index from constants
     draws = get_random_variable_draws_for_location(pd.Index([f'draw_{i}' for i in range(0, 1000)]), location, *Tuple)
 

--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -34,7 +34,7 @@ from vivarium_inputs.mapping_extension import alternative_risk_factors
 from vivarium_gates_iv_iron.constants import data_keys, metadata
 from vivarium_gates_iv_iron.data import utilities
 from vivarium_gates_iv_iron.utilities import (
-    get_norm_from_quantiles,
+    get_truncnorm_from_quantiles,
     get_random_variable_draws_for_location,
 )
 
@@ -320,7 +320,7 @@ def create_draws(df: pd.DataFrame, key: str, location: str):
     lower = df['lower_value']
     upper = df['upper_value']
 
-    Tuple = (key, utilities.get_truncnorm_from_quantiles(mean=mean, lower=lower, upper=upper))
+    Tuple = (key, get_truncnorm_from_quantiles(mean=mean, lower=lower, upper=upper))
     # pull index from constants
     draws = get_random_variable_draws_for_location(pd.Index([f'draw_{i}' for i in range(0, 1000)]), location, *Tuple)
 

--- a/src/vivarium_gates_iv_iron/data/utilities.py
+++ b/src/vivarium_gates_iv_iron/data/utilities.py
@@ -234,13 +234,3 @@ def get_gbd_age_bins(age_group_ids: List[int] = None) -> pd.DataFrame:
     # set age start for birth prevalence age bin to -1 to avoid validation issues
     age_bins.loc[age_bins['age_end'] == 0.0, 'age_start'] = -1.0
     return age_bins
-
-
-def get_truncnorm_from_quantiles(mean: float, lower: float, upper: float,
-                                 quantiles: Tuple[float, float] = (0.025, 0.975),
-                                 lower_clip: float = 0.0, upper_clip: float = 1.0) -> stats.truncnorm:
-    stdnorm_quantiles = stats.norm.ppf(quantiles)
-    sd = (upper - lower) / (stdnorm_quantiles[1] - stdnorm_quantiles[0])
-    a = (lower_clip - mean) / sd if sd else 0.0
-    b = (upper_clip - mean) / sd if sd else 0.0
-    return stats.truncnorm(loc=mean, scale=sd, a=a, b=b)

--- a/src/vivarium_gates_iv_iron/data/utilities.py
+++ b/src/vivarium_gates_iv_iron/data/utilities.py
@@ -3,7 +3,6 @@ from typing import List, Set, Union, Tuple
 import warnings
 
 import pandas as pd
-from scipy import stats
 
 from gbd_mapping import causes, covariates, risk_factors, Cause, ModelableEntity, RiskFactor
 from vivarium.framework.artifact import EntityKey

--- a/src/vivarium_gates_iv_iron/utilities.py
+++ b/src/vivarium_gates_iv_iron/utilities.py
@@ -103,3 +103,17 @@ def get_norm_from_quantiles(mean: float, lower: float, upper: float,
     stdnorm_quantiles = stats.norm.ppf(quantiles)
     sd = (upper - lower) / (stdnorm_quantiles[1] - stdnorm_quantiles[0])
     return stats.norm(loc=mean, scale=sd)
+
+
+def get_truncnorm_from_quantiles(mean: float, lower: float, upper: float,
+                                 quantiles: Tuple[float, float] = (0.025, 0.975),
+                                 lower_clip: float = 0.0, upper_clip: float = 1.0) -> stats.truncnorm:
+    stdnorm_quantiles = stats.norm.ppf(quantiles)
+    sd = (upper - lower) / (stdnorm_quantiles[1] - stdnorm_quantiles[0])
+    try:
+        a = (lower_clip - mean) / sd
+        b = (upper_clip - mean) / sd
+        return stats.truncnorm(loc=mean, scale=sd, a=a, b=b)
+    except ZeroDivisionError:
+        # degenerate case: if upper == lower, then use the mean with sd==0
+        return stats.norm(loc=mean, scale=sd)


### PR DESCRIPTION
## Change ASFR to use truncated norm, update development dependencies

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-2946](https://jira.ihme.washington.edu/browse/MIC-2946)
- *Research reference*: [See V&V notes](https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_iv_iron/maternal_model/concept_model.html?highlight=truncated%20normal#models)

Updates ASFR to use a truncated normal distribution. Also, updates the
pins for Vivarium Cluster Tools and Vivarium Inputs to latest releases.

### Verification and Testing
Rebuilt artifacts and ran models for South Asia and Sub-Saharan Africa.
Results appeared as expected.

