### PR TITLE
Updated maternal disorders equation and minor refactoring

### DIFF
--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -243,6 +243,9 @@ class PregnancyObserver:
         }
     }
 
+    def __init__(self):
+        self.previous_state_column_name = "previous_state"
+
     def __repr__(self):
         return 'PregnancyObserver()'
 
@@ -271,12 +274,11 @@ class PregnancyObserver:
         self.person_time = Counter()
         self.counts = Counter()
 
-        self.previous_state_column = "previous_state"
         builder.population.initializes_simulants(self.on_initialize_simulants,
-                                                 creates_columns=[self.previous_state_column])
+                                                 creates_columns=[self.previous_state_column_name])
 
         columns_required = ['alive', 'pregnancy_status', 'pregnancy_outcome', 'pregnancy_state_change_date',
-                            self.previous_state_column]
+                            self.previous_state_column_name]
 
         if self.configuration.by_age:
             columns_required += ['age']
@@ -289,7 +291,7 @@ class PregnancyObserver:
         builder.value.register_value_modifier('metrics', self.metrics)
 
     def on_initialize_simulants(self, pop_data):
-        self.population_view.update(pd.Series('', index=pop_data.index, name=self.previous_state_column))
+        self.population_view.update(pd.Series('', index=pop_data.index, name=self.previous_state_column_name))
 
     def on_time_step_prepare(self, event: Event):
         pop = self.population_view.get(event.index)
@@ -319,12 +321,12 @@ class PregnancyObserver:
 
         # This enables tracking of transitions between states
         prior_state_pop = self.population_view.get(event.index)
-        prior_state_pop[self.previous_state_column] = prior_state_pop["pregnancy_status"]
+        prior_state_pop[self.previous_state_column_name] = prior_state_pop["pregnancy_status"]
         self.population_view.update(prior_state_pop)
 
         # This enables tracking of transitions between states
         prior_state_pop = self.population_view.get(event.index)
-        prior_state_pop[self.previous_state_column] = prior_state_pop["pregnancy_status"]
+        prior_state_pop[self.previous_state_column_name] = prior_state_pop["pregnancy_status"]
         self.population_view.update(prior_state_pop)
 
     def on_collect_metrics(self, event: Event):
@@ -338,7 +340,7 @@ class PregnancyObserver:
             base_key = get_output_template(**configuration).substitute(measure=f'{transition}_count',
                                                                        year=event.time.year)
             base_filter = QueryString(
-                f'alive == "alive" and {self.previous_state_column} == "{transition.from_state}" and pregnancy_status == "{transition.to_state}"')
+                f'alive == "alive" and {self.previous_state_column_name} == "{transition.from_state}" and pregnancy_status == "{transition.to_state}"')
             counts_this_step.update(get_group_counts(pop, base_filter, base_key, self.configuration, self.age_bins))
 
         # get pregnancy outcome counts


### PR DESCRIPTION
## Update to maternal disorders equation and minor refactoring.

### Description
Update for maternal disorders equation calculating probabilities and minor refactoring to clean up pregnancy class.
- *Category*: Implementation
- *JIRA issue*: [MIC-2945](https://jira.ihme.washington.edu/browse/MIC-2945)
- *Research reference*: https://github.com/ihmeuw/vivarium_research/pull/818

Changed equation calculating maternal disorder probabilities to include not pregnant prevalence in the denominator and a minor refactor to the pregnancy class mainly adding index columns as a class attribute.

### Verification and Testing
Did a run and ran make_results and results look as expected.

```,year,measure,input_draw,scenario,age,value
0,2022,maternal_disorder_incident_counts,0,baseline,5_to_9,0
1,2022,maternal_disorder_incident_counts,0,baseline,10_to_14,2
2,2022,maternal_disorder_incident_counts,0,baseline,15_to_19,38
3,2022,maternal_disorder_incident_counts,0,baseline,20_to_24,141
4,2022,maternal_disorder_incident_counts,0,baseline,25_to_29,108
5,2022,maternal_disorder_incident_counts,0,baseline,30_to_34,62
6,2022,maternal_disorder_incident_counts,0,baseline,35_to_39,34
7,2022,maternal_disorder_incident_counts,0,baseline,40_to_44,9
8,2022,maternal_disorder_incident_counts,0,baseline,45_to_49,3
9,2022,maternal_disorder_incident_counts,0,baseline,50_to_54,1
10,2022,maternal_disorder_incident_counts,0,baseline,55_to_59,0


