### PR TITLE
Hemoglobin Exposure Model 3 Artifact

### DIFF
--- a/src/vivarium_gates_iv_iron/components/__init__.py
+++ b/src/vivarium_gates_iv_iron/components/__init__.py
@@ -3,3 +3,4 @@ from vivarium_gates_iv_iron.components.observers import (
     MaternalDisordersObserver, MaternalHemorrhageObserver,
 )
 from vivarium_gates_iv_iron.components.pregnancy import Pregnancy
+

--- a/src/vivarium_gates_iv_iron/components/hemoglobin.py
+++ b/src/vivarium_gates_iv_iron/components/hemoglobin.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-import scipy
+import scipy.stats
 
 from vivarium.framework.engine import Builder
 from vivarium.framework.population import SimulantData
@@ -61,6 +61,7 @@ class Hemoglobin:
                                                  requires_streams=[self.name])
 
         self.population_view = builder.population.get_view(self.columns_created)
+        builder.event.register_listener("time_step", self.on_time_step)
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         location_weights = self.location_weights(pop_data.index)
@@ -71,6 +72,12 @@ class Hemoglobin:
                                    "hemoglobin_percentile": self.randomness.get_draw(pop_data.index, additional_key="hemoglobin_percentile")},
                                   index=pop_data.index)
         self.population_view.update(pop_update)
+
+    def on_time_step(self, event):
+        self.distribution_parameters(event.index)
+        self.hemoglobin(event.index)
+        breakpoint()
+        return
 
     def hemoglobin_source(self, idx: pd.Index) -> pd.Series:
         distribution_parameters = self.distribution_parameters(idx)

--- a/src/vivarium_gates_iv_iron/components/hemoglobin.py
+++ b/src/vivarium_gates_iv_iron/components/hemoglobin.py
@@ -45,14 +45,12 @@ class Hemoglobin:
         stddev = pd.concat(stddev_dfs).set_index(index_columns)["value"].rename("stddev")
         # <<<--- TODO replace
         distribution_parameters = pd.concat([mean, stddev], axis=1).reset_index()
-        # TODO: look in Risk code to make sure we have canonical exposure naming
         self.distribution_parameters = builder.value.register_value_producer("hemoglobin.exposure_parameters",
             source=builder.lookup.build_table(distribution_parameters, key_columns=["sex", "country"], parameter_columns=["age", "year"]),
                                                                              requires_columns=["age", "sex", "country"])
         self.location_weights = builder.lookup.build_table(location_weights, key_columns=["sex"],
                                                            parameter_columns=["age", "year"])
-        # TODO: canonical naming
-        self.hemoglobin = builder.value.register_value_producer("hemoglobin", source=self.hemoglobin_source,
+        self.hemoglobin = builder.value.register_value_producer("hemoglobin.exposure", source=self.hemoglobin_source,
                                                                 requires_values=["hemoglobin.exposure_parameters"],
                                                                 requires_streams=[self.name])
 

--- a/src/vivarium_gates_iv_iron/components/hemoglobin.py
+++ b/src/vivarium_gates_iv_iron/components/hemoglobin.py
@@ -2,7 +2,12 @@ import numpy as np
 import pandas as pd
 import scipy
 
+from vivarium.framework.engine import Builder
+from vivarium.framework.population import SimulantData
+
+
 from vivarium_gates_iv_iron.constants.data_values import HEMOGLOBIN_DISTRIBUTION_PARAMETERS
+from vivarium_gates_iv_iron.constants import data_keys
 
 
 class Hemoglobin:
@@ -15,6 +20,63 @@ class Hemoglobin:
     @property
     def name(self):
         return "hemoglobin"
+
+    def setup(self, builder: Builder):
+        self.randomness = builder.randomness.get_stream(self.name)
+        self.columns_created = ["country", "hemoglobin_distribution_propensity", "hemoglobin_percentile"]
+        # load data
+        mean = builder.data.load(data_keys.HEMOGLOBIN.MEAN)
+        stddev = builder.data.load(data_keys.HEMOGLOBIN.STANDARD_DEVIATION)
+        # TODO replace --->>>
+        location_weights = mean.copy().drop(columns=["value"])
+        # lookup data, categorical column "country"
+        mean_dfs, stddev_dfs = [], []
+        # TODO have this in artifact and correct the location weights
+        for country in ["Bangladesh", "Pakistan", "India"]:
+            loc_mean = mean.copy()
+            loc_stddev = stddev.copy()
+            loc_mean["country"] = country
+            loc_stddev["country"] = country
+            mean_dfs.append(loc_mean)
+            stddev_dfs.append(loc_stddev)
+            location_weights[country] = 1/3  # will be pop of country over pop of region
+        index_columns = ["country", "sex", "age_start", 'age_end', 'year_start', 'year_end']
+        mean = pd.concat(mean_dfs).set_index(index_columns)["value"].rename("mean")
+        stddev = pd.concat(stddev_dfs).set_index(index_columns)["value"].rename("stddev")
+        # <<<--- TODO replace
+        distribution_parameters = pd.concat([mean, stddev], axis=1).reset_index()
+        # TODO: look in Risk code to make sure we have canonical exposure naming
+        self.distribution_parameters = builder.value.register_value_producer("hemoglobin.exposure_parameters",
+            source=builder.lookup.build_table(distribution_parameters, key_columns=["sex", "country"], parameter_columns=["age", "year"]),
+                                                                             requires_columns=["age", "sex", "country"])
+        self.location_weights = builder.lookup.build_table(location_weights, key_columns=["sex"],
+                                                           parameter_columns=["age", "year"])
+        # TODO: canonical naming
+        self.hemoglobin = builder.value.register_value_producer("hemoglobin", source=self.hemoglobin_source,
+                                                                requires_values=["hemoglobin.exposure_parameters"],
+                                                                requires_streams=[self.name])
+
+        builder.population.initializes_simulants(self.on_initialize_simulants,
+                                                 creates_columns=self.columns_created,
+                                                 requires_streams=[self.name])
+
+        self.population_view = builder.population.get_view(self.columns_created)
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        location_weights = self.location_weights(pop_data.index)
+        pop_update = pd.DataFrame({"country": self.randomness.choice(pop_data.index, choices=location_weights.columns.tolist(),
+                                                                     p=location_weights, additional_key="country"),
+                                   "hemoglobin_distribution_propensity": self.randomness.get_draw(pop_data.index,
+                                                                                     additional_key="hemoglobin_distribution_propensity"),
+                                   "hemoglobin_percentile": self.randomness.get_draw(pop_data.index, additional_key="hemoglobin_percentile")},
+                                  index=pop_data.index)
+        self.population_view.update(pop_update)
+
+    def hemoglobin_source(self, idx: pd.Index) -> pd.Series:
+        distribution_parameters = self.distribution_parameters(idx)
+        pop = self.population_view.get(idx)
+        return self.sample_from_hemoglobin_distribution(pop["hemoglobin_distribution_propensity"], pop["hemoglobin_percentile"], distribution_parameters)
+
 
     @staticmethod
     def _gamma_ppf(propensity, mean, sd):
@@ -48,12 +110,12 @@ class Hemoglobin:
         """
 
         exposure_data = exposure_parameters
-        mean = exposure_data['mean']
-        sd = exposure_data['sd']
+        mean = exposure_data["mean"]
+        sd = exposure_data["stddev"]
 
         gamma = propensity_distribution < 0.4
         gumbel = ~gamma
-        ret_val = pd.Series(index=propensity_distribution.index, name='value')
+        ret_val = pd.Series(index=propensity_distribution.index, name="value")
         ret_val.loc[gamma] = self._gamma_ppf(propensity.loc[gamma], mean, sd)
         ret_val.loc[gumbel] = self._mirrored_gumbel_ppf(propensity.loc[gumbel], mean, sd)
         return ret_val

--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -354,7 +354,9 @@ class Pregnancy:
         return disability_weight
 
     def hemoglobin_pregnancy_adjustment(self, index: pd.Index, df: pd.DataFrame) -> pd.DataFrame:
-        df['mean'] = df['mean'] * HEMOGLOBIN_DISTRIBUTION_PARAMETERS.PREGNANCY_MEAN_ADJUSTMENT_FACTOR
-        df['stddev'] = df['stddev'] * HEMOGLOBIN_DISTRIBUTION_PARAMETERS.PREGNANCY_STANDARD_DEVIATION_ADJUSTMENT_FACTOR
 
+        mean = HEMOGLOBIN_DISTRIBUTION_PARAMETERS.PREGNANCY_MEAN_ADJUSTMENT_FACTOR[0]
+        stddev = HEMOGLOBIN_DISTRIBUTION_PARAMETERS.PREGNANCY_STANDARD_DEVIATION_ADJUSTMENT_FACTOR
+        df['mean'] = df['mean'] * mean
+        df['stddev'] = df['stddev'] * stddev
         return df

--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -5,6 +5,7 @@ from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
 from vivarium_public_health.population import Mortality
+from vivarium_gates_iv_iron.components.hemoglobin import Hemoglobin
 from vivarium_gates_iv_iron.constants import models, data_keys, metadata
 from vivarium_gates_iv_iron.constants.data_values import (POSTPARTUM_DURATION_DAYS, PREPOSTPARTUM_DURATION_DAYS,
                                                           PREPOSTPARTUM_DURATION_RATIO, POSTPARTUM_DURATION_RATIO)
@@ -17,6 +18,10 @@ class Pregnancy:
     @property
     def name(self):
         return models.PREGNANCY_MODEL_NAME
+
+    @property
+    def sub_components(self):
+        return [Hemoglobin()]
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):

--- a/src/vivarium_gates_iv_iron/constants/data_keys.py
+++ b/src/vivarium_gates_iv_iron/constants/data_keys.py
@@ -17,6 +17,7 @@ class __Population(NamedTuple):
     DEMOGRAPHY: str = "population.demographic_dimensions"
     TMRLE: str = "population.theoretical_minimum_risk_life_expectancy"
     ACMR: str = "cause.all_causes.cause_specific_mortality_rate"
+    PLW_LOCATION_WEIGHTS: str = "population.pregnant_and_lactating_women_location_weight"
 
     @property
     def name(self):

--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -304,13 +304,14 @@ def load_lbwsg_exposure(key: str, location: str) -> pd.DataFrame:
     return data
 
 
-def create_draws(df: pd.DataFrame, key: str, location: str):
+def create_draws(df: pd.DataFrame, key: str, location: str, distribution_function=get_truncnorm_from_quantiles):
     """
     Parameters
     ----------
     df: Multi-index dataframe with mean, lower, and upper values columns.
     location
     key:
+    distribution_function: Distribution function to use to create draws
     Returns
     -------
 
@@ -320,7 +321,7 @@ def create_draws(df: pd.DataFrame, key: str, location: str):
     lower = df['lower_value']
     upper = df['upper_value']
 
-    Tuple = (key, get_truncnorm_from_quantiles(mean=mean, lower=lower, upper=upper))
+    Tuple = (key, distribution_function(mean=mean, lower=lower, upper=upper))
     # pull index from constants
     draws = get_random_variable_draws_for_location(pd.Index([f'draw_{i}' for i in range(0, 1000)]), location, *Tuple)
 

--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -456,11 +456,11 @@ def load_maternal_disorders_ylds(key: str, location: str) -> pd.DataFrame:
 
 
 def get_hemoglobin_data(key: str, location: str):
-    national_level_hemoglobin_data = pd.DataFrame()
+    country_dfs = []
     child_locs = get_child_locs(location)
 
     for loc in child_locs:
-        location_id = utility_data.get_location_id(location) if isinstance(location, str) else location
+        location_id = utility_data.get_location_id(loc) if isinstance(loc, str) else loc
         if key == data_keys.HEMOGLOBIN.MEAN:
             me_id = 10487
         elif key == data_keys.HEMOGLOBIN.STANDARD_DEVIATION:
@@ -469,9 +469,13 @@ def get_hemoglobin_data(key: str, location: str):
             raise KeyError("Invalid Hemoglobin key")
 
         hemoglobin_data = gbd.get_modelable_entity_draws(me_id=me_id, location_id=location_id)
-        hemoglobin_data = reshape_to_vivarium_format(hemoglobin_data, location)
+        hemoglobin_data = reshape_to_vivarium_format(hemoglobin_data, loc)
+        hemoglobin_data = pd.concat([hemoglobin_data], keys=[loc], names=['location'])
+        country_dfs.append(hemoglobin_data)
 
-    return hemoglobin_data
+    national_level_hemoglobin_data = pd.conat(country_dfs)
+
+    return national_level_hemoglobin_data
 
 
 def get_pregnant_lactating_women_location_weights(key: str, location: str):

--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -476,7 +476,7 @@ def get_hemoglobin_data(key: str, location: str):
         hemoglobin_data = pd.concat([hemoglobin_data], keys=[loc], names=['location'])
         country_dfs.append(hemoglobin_data)
 
-    national_level_hemoglobin_data = pd.conat(country_dfs)
+    national_level_hemoglobin_data = pd.concat(country_dfs)
 
     return national_level_hemoglobin_data
 

--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -456,16 +456,35 @@ def load_maternal_disorders_ylds(key: str, location: str) -> pd.DataFrame:
 
 
 def get_hemoglobin_data(key: str, location: str):
-    location_id = utility_data.get_location_id(location) if isinstance(location, str) else location
-    if key == data_keys.HEMOGLOBIN.MEAN:
-        me_id = 10487
-    elif key == data_keys.HEMOGLOBIN.STANDARD_DEVIATION:
-        me_id = 10488
-    else:
-        raise KeyError("Invalid Hemoglobin key")
+    national_level_hemoglobin_data = pd.DataFrame()
+    child_locs = get_child_locs(location)
 
-    hemoglobin_data = gbd.get_modelable_entity_draws(me_id=me_id, location_id=location_id)
-    hemoglobin_data = reshape_to_vivarium_format(hemoglobin_data, location)
-    hemoglobin_data = subset_to_wra(hemoglobin_data)
+    for loc in child_locs:
+        location_id = utility_data.get_location_id(location) if isinstance(location, str) else location
+        if key == data_keys.HEMOGLOBIN.MEAN:
+            me_id = 10487
+        elif key == data_keys.HEMOGLOBIN.STANDARD_DEVIATION:
+            me_id = 10488
+        else:
+            raise KeyError("Invalid Hemoglobin key")
+
+        hemoglobin_data = gbd.get_modelable_entity_draws(me_id=me_id, location_id=location_id)
+        hemoglobin_data = reshape_to_vivarium_format(hemoglobin_data, location)
 
     return hemoglobin_data
+
+
+def get_pregnant_lactating_women_location_weights(key: str, location: str):
+    #  WRA * (ASFR + (ASFR * SBR) + incidence_c996 + incidence_c374)
+    #      - divide by regional population
+    plw_location_weights, wra, asfr,  = pd.DataFrame()
+
+    child_locs = get_child_locs(location)
+
+    for loc in child_locs:
+        # Get WRA data
+        # get all data
+        # do math to calculate population of PLW
+        incidencec374 = get_data(key, loc)
+
+    # Divide each location by total region population

--- a/src/vivarium_gates_iv_iron/utilities.py
+++ b/src/vivarium_gates_iv_iron/utilities.py
@@ -117,3 +117,34 @@ def get_truncnorm_from_quantiles(mean: float, lower: float, upper: float,
     except ZeroDivisionError:
         # degenerate case: if upper == lower, then use the mean with sd==0
         return stats.norm(loc=mean, scale=sd)
+
+
+def get_lognorm_from_quantiles(mean: float, lower: float, upper: float,
+                               quantiles: Tuple[float, float] = (0.025, 0.975)) -> stats.lognorm:
+    """Returns a frozen lognormal distribution with the specified mean, such that
+    (lower, upper) are approximately equal to the quantiles with ranks
+    (quantile_ranks[0], quantile_ranks[1]).
+    """
+    # Let Y ~ norm(mu, sigma^2) and X = exp(Y), where mu = log(mean)
+    # so X ~ lognorm(s=sigma, scale=exp(mu)) in scipy's notation.
+    # We will determine sigma from the two specified quantiles lower and upper.
+    if not (lower <= mean <= upper):
+        raise ValueError(
+            f"The mean ({mean}) must be between the lower ({lower}) and upper ({upper}) "
+            "quantile values."
+        )
+    try:
+        # mean (and mean) of the normal random variable Y = log(X)
+        mu = np.log(mean)
+        # quantiles of the standard normal distribution corresponding to quantile_ranks
+        stdnorm_quantiles = stats.norm.ppf(quantiles)
+        # quantiles of Y = log(X) corresponding to the quantiles (lower, upper) for X
+        norm_quantiles = np.log([lower, upper])
+        # standard deviation of Y = log(X) computed from the above quantiles for Y
+        # and the corresponding standard normal quantiles
+        sigma = (norm_quantiles[1] - norm_quantiles[0]) / (stdnorm_quantiles[1] - stdnorm_quantiles[0])
+        # Frozen lognormal distribution for X = exp(Y)
+        # (s=sigma is the shape parameter; the scale parameter is exp(mu), which equals the mean)
+        return stats.lognorm(s=sigma, scale=mean)
+    except:
+        return stats.norm(loc=mean, scale=0)


### PR DESCRIPTION
## Hemoglobin Exposure Model 3 Artifact

### Description
Update to artifact to include hemoglobin exposure with location weights for pregnant and lactating women.  Also includes small changes to loader to clean artifact data that was being subset.
- *Category*: Data artifact
- *JIRA issue*: [MIC-2954](https://jira.ihme.washington.edu/browse/MIC-2954)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_iv_iron/maternal_model/concept_model.html#hemoglobin-distribution-weighting-strategy

Added hemoglobin exposure data to artifact with location weights.  Update to artifact keys that were being subset.

### Verification and Testing
Ran make_artifacts for both South Asia and Sub-Saharan Africa locations.  Loaded artifact data and data looks as expected.  Hemoglobin exposure and location weights sum to 1.

