### PR TITLE
Correct bad merge conflict resolution, correct typo

### DIFF
--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -662,16 +662,13 @@ class MaternalHemorrhageObserver:
         pop = self.population_view.get(event.index)
 
         # Accrue all counts and time to the current year
-        state_person_time_this_step = utilities.get_state_person_time(
-            pop,
-            self.configuration,
-            "maternal_hemorrhage",
-            models.MATERNAL_HEMORRHAGE_STATE,
-            self.clock().year,
-            event.step_size,
-            self.age_bins,
-        )
-        self.person_time.update(state_person_time_this_step)
+        for state in models.MATERNAL_HEMORRHAGE_STATES:
+             # Accrue all counts and time to the current year
+             state_person_time_this_step = utilities.get_state_person_time(
+                 pop, self.configuration, 'maternal_hemorrhage', state, self.clock().year,
+                 event.step_size, self.age_bins
+             )
+             self.person_time.update(state_person_time_this_step)
 
     def on_collect_metrics(self, event: Event):
         counts_this_step = {}

--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -161,7 +161,7 @@ class Pregnancy:
                                                                         additional_key='pregnancy_outcome')
 
         pregnancy_outcome_probabilities = self.outcome_probabilities(is_postpartum_idx)[list(models.PREGNANCY_OUTCOMES)]
-        pregnancy_outcome.loc[is_pregnant_idx] = self.randomness.choice(is_postpartum_idx,
+        pregnancy_outcome.loc[is_postpartum_idx] = self.randomness.choice(is_postpartum_idx,
                                                                         choices=models.PREGNANCY_OUTCOMES,
                                                                         p=pregnancy_outcome_probabilities,
                                                                         additional_key='pregnancy_outcome')


### PR DESCRIPTION
## Correct bad merge conflict resolution, correct typo

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3011](https://jira.ihme.washington.edu/browse/MIC-3011)
- *Research reference*: n/a

Corrects a bad merge conflict resolution on the maternal hemorrhage split. Also corrects where a wrong mask was used on simulants who were postpartum at initialization.

### Verification and Testing
Ran a couple timesteps, looks good.

