### PR TITLE
Bugfix/pregnancy status

### DIFF
--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -214,8 +214,9 @@ class Pregnancy:
     def on_time_step(self, event: Event):
         pop = self.population_view.get(event.index, query="alive =='alive'")
         conception_rate = self.conception_rate(pop.index)
-        pregnant_this_step = self.randomness.filter_for_rate(pop.index, conception_rate,
-                                                             additional_key='new_pregnancy')
+        pregnant_this_step = self.randomness.filter_for_rate(pop.index, conception_rate, additional_key='new_pregnancy')
+        pregnant_this_step = (pop['pregnancy_status'] == models.NOT_PREGNANT_STATE) & pregnant_this_step
+
         p = self.outcome_probabilities(pop.index)[list(models.PREGNANCY_OUTCOMES)]
         pregnancy_outcome = self.randomness.choice(pop.index, choices=models.PREGNANCY_OUTCOMES, p=p,
                                                    additional_key='pregnancy_outcome')

--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -214,7 +214,10 @@ class Pregnancy:
     def on_time_step(self, event: Event):
         pop = self.population_view.get(event.index, query="alive =='alive'")
         conception_rate = self.conception_rate(pop.index)
-        pregnant_this_step = self.randomness.filter_for_rate(pop.index, conception_rate, additional_key='new_pregnancy')
+
+        pregnant_this_step = pd.Series(False, index=pop.index)
+        pregnant_this_step_idx = self.randomness.filter_for_rate(pop.index, conception_rate, additional_key='new_pregnancy')
+        pregnant_this_step.loc[pregnant_this_step_idx] = True
         pregnant_this_step = (pop['pregnancy_status'] == models.NOT_PREGNANT_STATE) & pregnant_this_step
 
         p = self.outcome_probabilities(pop.index)[list(models.PREGNANCY_OUTCOMES)]


### PR DESCRIPTION
## Bugfix for pregnancy status.

### Description
- *Category*: Bugfix
- *JIRA issue*: [MIC-3011](https://jira.ihme.washington.edu/browse/MIC-3011)

Bugfix for pregnancy status where simulants could get pregnant while in any model state.

### Verification and Testing
Ran simulate_run and saw expected results that only simulants in not pregnant state can become pregnant.

