### PR TITLE
Bugfix for pregnancy outcomes and other V&V issues.

### DIFF
--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -412,13 +412,6 @@ class PregnancyObserver:
         ]
         self.population_view.update(prior_state_pop)
 
-        # This enables tracking of transitions between states
-        prior_state_pop = self.population_view.get(event.index)
-        prior_state_pop[self.previous_state_column_name] = prior_state_pop[
-            "pregnancy_status"
-        ]
-        self.population_view.update(prior_state_pop)
-
     def on_collect_metrics(self, event: Event):
         counts_this_step = {}
         pop = self.population_view.get(event.index)

--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -438,7 +438,7 @@ class PregnancyObserver:
                 measure=f"{outcome}_count", year=event.time.year
             )
             base_filter = QueryString(
-                f'alive == "alive" and pregnancy_status == "postpartum" and pregnancy_outcome == "{outcome}"'
+                f'alive == "alive" and (pregnancy_status == "{models.MATERNAL_DISORDER_STATE}" or pregnancy_status == "{models.NO_MATERNAL_DISORDER_STATE}") and pregnancy_outcome == "{outcome}"'
             )
             counts_this_step.update(
                 get_group_counts(

--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -681,7 +681,7 @@ class MaternalHemorrhageObserver:
             base_key = get_output_template(**configuration).substitute(measure=f'incident_cases_of_{state}',
                                                                        year=event.time.year)
             base_filter = QueryString(
-                f'alive == "alive" and pregnancy_status != "postpartum" and maternal_hemorrhage == "{state}"')
+                f'alive == "alive" and maternal_hemorrhage == "{state}"')
             counts_this_step.update(get_group_counts(pregnancy_change_this_step_pop,
                                                      base_filter, base_key,
                                                      self.configuration,

--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -153,7 +153,10 @@ class Pregnancy:
         pregnancy_outcome = pd.Series(models.INVALID_OUTCOME, index=pop_data.index)
         is_pregnant_idx = pop_data.index[pregnancy_status == models.PREGNANT_STATE]
         is_postpartum_idx = pop_data.index[pregnancy_status == models.POSTPARTUM_STATE]
+        is_prepostpartum_idx = pop_data.index[((pregnancy_status == models.NO_MATERNAL_DISORDER_STATE)
+                                               | (pregnancy_status == models.MATERNAL_DISORDER_STATE))]
 
+        # TODO refactor these calls...
         pregnancy_outcome_probabilities = self.outcome_probabilities(is_pregnant_idx)[list(models.PREGNANCY_OUTCOMES)]
         pregnancy_outcome.loc[is_pregnant_idx] = self.randomness.choice(is_pregnant_idx,
                                                                         choices=models.PREGNANCY_OUTCOMES,
@@ -162,6 +165,12 @@ class Pregnancy:
 
         pregnancy_outcome_probabilities = self.outcome_probabilities(is_postpartum_idx)[list(models.PREGNANCY_OUTCOMES)]
         pregnancy_outcome.loc[is_postpartum_idx] = self.randomness.choice(is_postpartum_idx,
+                                                                        choices=models.PREGNANCY_OUTCOMES,
+                                                                        p=pregnancy_outcome_probabilities,
+                                                                        additional_key='pregnancy_outcome')
+
+        pregnancy_outcome_probabilities = self.outcome_probabilities(is_prepostpartum_idx)[list(models.PREGNANCY_OUTCOMES)]
+        pregnancy_outcome.loc[is_prepostpartum_idx] = self.randomness.choice(is_prepostpartum_idx,
                                                                         choices=models.PREGNANCY_OUTCOMES,
                                                                         p=pregnancy_outcome_probabilities,
                                                                         additional_key='pregnancy_outcome')
@@ -190,6 +199,8 @@ class Pregnancy:
         postpartum_start_date = pop_data.creation_time - days_until_postpartum_ends
         pregnancy_state_change_date.loc[is_pregnant_idx] = conception_date.loc[is_pregnant_idx]
         pregnancy_state_change_date.loc[is_postpartum_idx] = postpartum_start_date.loc[is_postpartum_idx]
+        pregnancy_state_change_date.loc[is_prepostpartum_idx] = (pop_data.creation_time
+                                                                 - pd.Timedelta(days=PREPOSTPARTUM_DURATION_DAYS))
 
         # initialize columns for 'cause_of_death', 'years_of_life_lost'
         cause_of_death = pd.Series("not_dead", index=pop_data.index, dtype="string")

--- a/src/vivarium_gates_iv_iron/constants/metadata.py
+++ b/src/vivarium_gates_iv_iron/constants/metadata.py
@@ -14,7 +14,7 @@ ARTIFACT_INDEX_COLUMNS = [
 ]
 
 PROJECT_NAME = "vivarium_gates_iv_iron"
-CLUSTER_PROJECT = "proj_cost_effect"
+CLUSTER_PROJECT = "proj_simscience"
 
 CLUSTER_QUEUE = "all.q"
 MAKE_ARTIFACT_MEM = "10G"


### PR DESCRIPTION
## Bugfix for pregnancy outcomes and other V&V issues

### Description
- *Category*: Bugfix
- *JIRA issue*: [MIC-3011](https://jira.ihme.washington.edu/browse/MIC-3011) 
- *Research reference*: https://github.com/ihmeuw/vivarium_research_iv_iron/pull/16

Resolved bugs in observers that were affecting pregnancy transition counts.  Fixed bug that was preventing simulants from being assigned a pregnancy outcome at initialization.  Changed default cluster project.

### Verification and Testing
Did a full model run and pregnancy counts and transitions in new results are equal showing that the model and observers are working as intended.

