### PR TITLE
Bugfix to maternal hemorrhage incidence and counts

### DIFF
--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -665,7 +665,11 @@ class MaternalHemorrhageObserver:
         counts_this_step = {}
         pop = self.population_view.get(event.index)
         pregnancy_change_this_step_pop = pop[
-            pop["pregnancy_state_change_date"] == event.time
+            (pop["pregnancy_state_change_date"] == event.time)
+            & (
+                (pop["pregnancy_status"] == models.MATERNAL_DISORDER_STATE)
+                | (pop["pregnancy_status"] == models.NO_MATERNAL_DISORDER_STATE)
+            )
         ]
         configuration = self.configuration.to_dict()
 

--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -122,8 +122,12 @@ class Pregnancy:
 
         maternal_hemorrhage_incidence_rate = builder.data.load(data_keys.MATERNAL_HEMORRHAGE.INCIDENCE_RATE).set_index(
             self.index_cols)
+        maternal_hemorrhage_csmr = builder.data.load(data_keys.MATERNAL_HEMORRHAGE.CSMR).set_index(self.index_cols)
+        calculated_maternal_hemorrhage_incidence_rate = (
+                (maternal_hemorrhage_incidence_rate - maternal_hemorrhage_csmr)
+                / (not_pregnant_prevalence * not_pregnant_prevalence))
         self.probability_maternal_hemorrhage = builder.lookup.build_table(
-            maternal_hemorrhage_incidence_rate.reset_index(),
+            calculated_maternal_hemorrhage_incidence_rate.reset_index(),
             key_columns=['sex'],
             parameter_columns=['age', 'year'])
         # Get value for the probability of moderate maternal hemorrhage. The probability of severe maternal

--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -125,7 +125,7 @@ class Pregnancy:
         maternal_hemorrhage_csmr = builder.data.load(data_keys.MATERNAL_HEMORRHAGE.CSMR).set_index(self.index_cols)
         calculated_maternal_hemorrhage_incidence_rate = (
                 (maternal_hemorrhage_incidence_rate - maternal_hemorrhage_csmr)
-                / (not_pregnant_prevalence * not_pregnant_prevalence))
+                / (conception_rate_data * not_pregnant_prevalence))
         self.probability_maternal_hemorrhage = builder.lookup.build_table(
             calculated_maternal_hemorrhage_incidence_rate.reset_index(),
             key_columns=['sex'],


### PR DESCRIPTION
## Bugfix to maternal hemorrhage incidence and counts

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3011](https://jira.ihme.washington.edu/browse/MIC-3011)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/causes/maternal_hemorrhage_incidence/index.html#id5

The existing implementation erred by not limiting counts of incident maternal hemorrhage cases at every transition in the pregnancy model rather than limited to the actual event which only happens on transition out of the pregnant state. This corrects that counting.

Also, this change corrects the code for incident maternal hemorrhage cases rate per birth to match concept model document.

### Verification and Testing
Parallel run on South Asia. We hit maternal hemorrhage expected trends from the artifact on the nose.
<img width="667" alt="Screen Shot 2022-04-14 at 12 38 39 AM" src="https://user-images.githubusercontent.com/13937263/163452873-f8bc41ac-b094-4126-99c5-4dc34a390ce0.png">
<img width="667" alt="Screen Shot 2022-04-14 at 12 38 06 AM" src="https://user-images.githubusercontent.com/13937263/163452882-604ab852-b96e-4a40-9fd8-401b13698ed9.png">

