### PR TITLE
Feature/pregnancy duration

### DIFF
--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -305,7 +305,10 @@ def load_lbwsg_exposure(key: str, location: str) -> pd.DataFrame:
     data = data[data['year_id'] == 2019].drop(columns='year_id')
     data = utilities.process_exposure(data, key, entity, location, metadata.GBD_2019_ROUND_ID,
                                       metadata.AGE_GROUP.GBD_2019_LBWSG_EXPOSURE | metadata.AGE_GROUP.GBD_2020)
-    data = data[data.index.get_level_values('year_start') == 2019]
+    data = data[
+        (data.index.get_level_values('year_start') == 2019)
+        & (data.index.get_level_values('age_end') == 0.0)
+    ]
     return data
 
 

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -7,13 +7,13 @@ components:
         - Pregnancy()
         - LBWSGExposure()
 
-        - DisabilityObserver()
-        - MortalityObserver()
-        - PregnancyObserver()
-        - MaternalDisordersObserver()
-        - MaternalHemorrhageObserver()
-        - HemoglobinObserver()
-        - AnemiaObserver()
+#        - DisabilityObserver()
+#        - MortalityObserver()
+#        - PregnancyObserver()
+#        - MaternalDisordersObserver()
+#        - MaternalHemorrhageObserver()
+#        - HemoglobinObserver()
+#        - AnemiaObserver()
 
 configuration:
     input_data:
@@ -42,6 +42,9 @@ configuration:
         age_start: 7
         age_end: 54
         pregnant_lactating_women: False
+
+    lbwsg_distribution:
+        sex_column: "sex_of_child"
 
     metrics:
         disability:

--- a/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
@@ -43,6 +43,9 @@ configuration:
         age_end: 54
         pregnant_lactating_women: False
 
+    lbwsg_distribution:
+        sex_column: "sex_of_child"
+
     metrics:
         disability:
             by_age: True


### PR DESCRIPTION
## Use LBWSG Distribution to set pregnancy duration
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-2994](https://jira.ihme.washington.edu/browse/MIC-2994)
- *Research reference*: [LBWSG documentation](https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/risk_exposures/low_birthweight_short_gestation/index.html#risk-exposure-lbwsg)

 Set pregnancy duration using the lbwsg distribution.
Moves sex_of_child column creation to the LBWSGExposure component so that the lbwsg exposure pipeline can reference it.
Deletes unneeded birth-weight column
Drops LBWSG exposure data for post birth populations, since only birth exposure is needed and the lookup table interpolator will use the oldest age group (since all mothers are older than 28 days).

### Verification and Testing
Tested by running an interactive sim.
