### PR TITLE
Copy in VPH pre-0.10.18 observers used as superclasses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "vivarium==0.10.10",
-        "vivarium_public_health==0.10.15",
+        "vivarium_public_health==0.10.18",
         "click",
         "gbd_mapping>=3.0.0, <4.0.0",
         "jinja2",

--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -6,18 +6,25 @@ import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.time import Time, get_time_stamp
-from vivarium.framework.values import (list_combiner, rescale_post_processor,
-                                       union_post_processor)
-from vivarium_public_health.disease import (DiseaseState,
-                                            RiskAttributableDisease)
+from vivarium.framework.values import (
+    list_combiner,
+    rescale_post_processor,
+    union_post_processor,
+)
+from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
 from vivarium_public_health.metrics import utilities
 from vivarium_public_health.metrics.utilities import (
-    QueryString, get_age_bins, get_deaths, get_group_counts,
-    get_output_template, get_person_time, get_years_lived_with_disability,
-    get_years_of_life_lost)
+    QueryString,
+    get_age_bins,
+    get_deaths,
+    get_group_counts,
+    get_output_template,
+    get_person_time,
+    get_years_lived_with_disability,
+    get_years_of_life_lost,
+)
 
-from vivarium_gates_iv_iron.constants import (data_keys, data_values, models,
-                                              results)
+from vivarium_gates_iv_iron.constants import data_keys, data_values, models, results
 
 
 class LegacyMortalityObserver:

--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -3,35 +3,200 @@ import itertools
 from typing import Callable, Dict, Iterable, List, Tuple, Union
 
 import pandas as pd
-from vivarium import ConfigTree
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
-from vivarium.framework.population import PopulationView
 from vivarium.framework.time import Time, get_time_stamp
-from vivarium.framework.values import Pipeline
+from vivarium.framework.values import list_combiner, rescale_post_processor, union_post_processor
 
-from vivarium_public_health.metrics import (
-    utilities,
-    MortalityObserver as MortalityObserver_,
-    DisabilityObserver as DisabilityObserver_,
-    DiseaseObserver as DiseaseObserver_,
-    CategoricalRiskObserver as CategoricalRiskObserver_,
-)
+from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
+from vivarium_public_health.metrics import utilities
 from vivarium_public_health.metrics.utilities import (
+    get_age_bins,
     get_group_counts,
     get_output_template,
     get_deaths,
-    get_state_person_time,
-    get_transition_count,
     get_years_lived_with_disability,
     get_years_of_life_lost,
     get_person_time,
     QueryString,
-    TransitionString,
 )
 
 from vivarium_gates_iv_iron.constants import models, results, data_keys, data_values
 
+
+class LegacyMortalityObserver:
+    """ An observer for cause-specific deaths, ylls, and total person time.
+
+    By default, this counts cause-specific deaths, years of life lost, and
+    total person time over the full course of the simulation. It can be
+    configured to bin these measures into age groups, sexes, and years
+    by setting the ``by_age``, ``by_sex``, and ``by_year`` flags, respectively.
+
+    In the model specification, your configuration for this component should
+    be specified as, e.g.:
+
+    .. code-block:: yaml
+
+        configuration:
+            metrics:
+                mortality:
+                    by_age: True
+                    by_year: False
+                    by_sex: True
+
+    """
+    configuration_defaults = {
+        'metrics': {
+            'mortality': {
+                'by_age': False,
+                'by_year': False,
+                'by_sex': False,
+            }
+        }
+    }
+
+    @property
+    def name(self):
+        return 'mortality_observer'
+
+    def setup(self, builder):
+        self.config = builder.configuration.metrics.mortality
+        self.clock = builder.time.clock()
+        self.step_size = builder.time.step_size()
+        self.start_time = self.clock()
+        self.initial_pop_entrance_time = self.start_time - self.step_size()
+        self.age_bins = get_age_bins(builder)
+        diseases = builder.components.get_components_by_type((DiseaseState, RiskAttributableDisease))
+        self.causes = [c.state_id for c in diseases] + ['other_causes']
+
+        life_expectancy_data = builder.data.load("population.theoretical_minimum_risk_life_expectancy")
+        self.life_expectancy = builder.lookup.build_table(life_expectancy_data, key_columns=[],
+                                                          parameter_columns=['age'])
+
+        columns_required = ['tracked', 'alive', 'entrance_time', 'exit_time', 'cause_of_death',
+                            'years_of_life_lost', 'age']
+        if self.config.by_sex:
+            columns_required += ['sex']
+        self.population_view = builder.population.get_view(columns_required)
+
+        builder.value.register_value_modifier('metrics', self.metrics)
+
+    def metrics(self, index, metrics):
+        pop = self.population_view.get(index)
+        pop.loc[pop.exit_time.isnull(), 'exit_time'] = self.clock()
+
+        person_time = get_person_time(pop, self.config.to_dict(), self.start_time, self.clock(), self.age_bins)
+        deaths = get_deaths(pop, self.config.to_dict(), self.start_time, self.clock(), self.age_bins, self.causes)
+        ylls = get_years_of_life_lost(pop, self.config.to_dict(), self.start_time, self.clock(),
+                                      self.age_bins, self.life_expectancy, self.causes)
+
+        metrics.update(person_time)
+        metrics.update(deaths)
+        metrics.update(ylls)
+
+        the_living = pop[(pop.alive == 'alive') & pop.tracked]
+        the_dead = pop[pop.alive == 'dead']
+        metrics['years_of_life_lost'] = self.life_expectancy(the_dead.index).sum()
+        metrics['total_population_living'] = len(the_living)
+        metrics['total_population_dead'] = len(the_dead)
+
+        return metrics
+
+    def __repr__(self):
+        return "MortalityObserver()"
+
+
+class LegacyDisabilityObserver:
+    """Counts years lived with disability.
+
+    By default, this counts both aggregate and cause-specific years lived
+    with disability over the full course of the simulation. It can be
+    configured to bin the cause-specific YLDs into age groups, sexes, and years
+    by setting the ``by_age``, ``by_sex``, and ``by_year`` flags, respectively.
+
+    In the model specification, your configuration for this component should
+    be specified as, e.g.:
+
+    .. code-block:: yaml
+
+        configuration:
+            metrics:
+                disability:
+                    by_age: True
+                    by_year: False
+                    by_sex: True
+
+    """
+    configuration_defaults = {
+        'metrics': {
+            'disability': {
+                'by_age': False,
+                'by_year': False,
+                'by_sex': False,
+            }
+        }
+    }
+
+    @property
+    def name(self):
+        return 'disability_observer'
+
+    def setup(self, builder):
+        self.config = builder.configuration.metrics.disability
+        self.age_bins = get_age_bins(builder)
+        self.clock = builder.time.clock()
+        self.step_size = builder.time.step_size()
+        self.causes = [c.state_id
+                       for c in builder.components.get_components_by_type((DiseaseState, RiskAttributableDisease))]
+        self.years_lived_with_disability = Counter()
+        self.disability_weight_pipelines = {cause: builder.value.get_value(f'{cause}.disability_weight')
+                                            for cause in self.causes}
+
+        self.disability_weight = builder.value.register_value_producer(
+            'disability_weight',
+            source=lambda index: [pd.Series(0.0, index=index)],
+            preferred_combiner=list_combiner,
+            preferred_post_processor=_disability_post_processor)
+
+        columns_required = ['tracked', 'alive', 'years_lived_with_disability']
+        if self.config.by_age:
+            columns_required += ['age']
+        if self.config.by_sex:
+            columns_required += ['sex']
+        self.population_view = builder.population.get_view(columns_required)
+        builder.population.initializes_simulants(self.initialize_disability,
+                                                 creates_columns=['years_lived_with_disability'])
+        # FIXME: The state table is modified before the clock advances.
+        # In order to get an accurate representation of person time we need to look at
+        # the state table before anything happens.
+        builder.event.register_listener('time_step__prepare', self.on_time_step_prepare)
+        builder.value.register_value_modifier('metrics', modifier=self.metrics)
+
+    def initialize_disability(self, pop_data):
+        self.population_view.update(pd.Series(0., index=pop_data.index, name='years_lived_with_disability'))
+
+    def on_time_step_prepare(self, event):
+        pop = self.population_view.get(event.index, query='tracked == True and alive == "alive"')
+        ylds_this_step = get_years_lived_with_disability(pop, self.config.to_dict(),
+                                                         self.clock().year, self.step_size(),
+                                                         self.age_bins, self.disability_weight_pipelines, self.causes)
+        self.years_lived_with_disability.update(ylds_this_step)
+
+        pop.loc[:, 'years_lived_with_disability'] += self.disability_weight(pop.index)
+        self.population_view.update(pop)
+
+    def metrics(self, index, metrics):
+        total_ylds = self.population_view.get(index)['years_lived_with_disability'].sum()
+        metrics['years_lived_with_disability'] = total_ylds
+        metrics.update(self.years_lived_with_disability)
+        return metrics
+
+    def __repr__(self):
+        return "DisabilityObserver()"
+
+
+def _disability_post_processor(value, step_size):
+    return rescale_post_processor(union_post_processor(value, step_size), step_size)
 
 class ResultsStratifier:
     """Centralized component for handling results stratification.
@@ -208,7 +373,7 @@ class ResultsStratifier:
         return measure_data
 
 
-class MortalityObserver(MortalityObserver_):
+class MortalityObserver(LegacyMortalityObserver):
     def __init__(self):
         super().__init__()
         self.stratifier = ResultsStratifier(self.name)
@@ -256,7 +421,7 @@ class MortalityObserver(MortalityObserver_):
         return metrics
 
 
-class DisabilityObserver(DisabilityObserver_):
+class DisabilityObserver(LegacyDisabilityObserver):
     def __init__(self):
         super().__init__()
         self.stratifier = ResultsStratifier(self.name)

--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -28,7 +28,7 @@ from vivarium_gates_iv_iron.constants import data_keys, data_values, models, res
 
 
 class LegacyMortalityObserver:
-    """An observer for cause-specific deaths, ylls, and total person time.
+    """(From vivarium_public_health 0.10.15) An observer for cause-specific deaths, ylls, and total person time.
 
     By default, this counts cause-specific deaths, years of life lost, and
     total person time over the full course of the simulation. It can be
@@ -139,7 +139,7 @@ class LegacyMortalityObserver:
 
 
 class LegacyDisabilityObserver:
-    """Counts years lived with disability.
+    """(From vivarium_public_health v0.10.15) Counts years lived with disability.
 
     By default, this counts both aggregate and cause-specific years lived
     with disability over the full course of the simulation. It can be
@@ -426,7 +426,7 @@ class ResultsStratifier:
         }
         return measure_data
 
-
+# TODO: Consider using VPH v0.10.18 MortalityObserver instead
 class MortalityObserver(LegacyMortalityObserver):
     def __init__(self):
         super().__init__()
@@ -475,6 +475,7 @@ class MortalityObserver(LegacyMortalityObserver):
         return metrics
 
 
+# TODO: Consider using VPH v0.10.18 DisabilityObserver instead
 class DisabilityObserver(LegacyDisabilityObserver):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## Copy in VPH pre-0.10.18 observers used as superclasses

### Description
- *Category*: observers
- *JIRA issue*: [MIC-3058](https://jira.ihme.washington.edu/browse/MIC-3058)
- *Research reference*: n/a

In preparation for the birth observer and LBWSG integration, we needed to update to vivarium_public_health (VPH) v0.10.18. In order to do that, two subclassed observer classes needed to be added as scaffolding to allow the Mortality and Disability observers to continue to work. Later, if time permits, the Mortality and Disability observers in the latest VPH versions.

### Verification and Testing
Ran a `simulate run`. Results were as expected.

