### PR TITLE
Child outputs implementation for LBWSG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "vivarium==0.10.10",
-        "vivarium_public_health==0.10.15",
+        "vivarium_public_health==0.10.18",
         "click",
         "gbd_mapping>=3.0.0, <4.0.0",
         "jinja2",

--- a/src/vivarium_gates_iv_iron/components/__init__.py
+++ b/src/vivarium_gates_iv_iron/components/__init__.py
@@ -1,10 +1,11 @@
-from vivarium_gates_iv_iron.components.observers import (
-    MortalityObserver,
-    DisabilityObserver,
-    PregnancyObserver,
-    MaternalDisordersObserver,
-    MaternalHemorrhageObserver,
-    HemoglobinObserver,
-    AnemiaObserver,
-)
+from vivarium_gates_iv_iron.components.child import LBWSGExposure
+# from vivarium_gates_iv_iron.components.observers import (
+#     MortalityObserver,
+#     DisabilityObserver,
+#     PregnancyObserver,
+#     MaternalDisordersObserver,
+#     MaternalHemorrhageObserver,
+#     HemoglobinObserver,
+#     AnemiaObserver,
+# )
 from vivarium_gates_iv_iron.components.pregnancy import Pregnancy

--- a/src/vivarium_gates_iv_iron/components/__init__.py
+++ b/src/vivarium_gates_iv_iron/components/__init__.py
@@ -1,11 +1,11 @@
-from vivarium_gates_iv_iron.components.child import LBWSGExposure
-# from vivarium_gates_iv_iron.components.observers import (
-#     MortalityObserver,
-#     DisabilityObserver,
-#     PregnancyObserver,
-#     MaternalDisordersObserver,
-#     MaternalHemorrhageObserver,
-#     HemoglobinObserver,
-#     AnemiaObserver,
-# )
+from vivarium_gates_iv_iron.components.child import BirthObserver, LBWSGExposure
+from vivarium_gates_iv_iron.components.observers import (
+    MortalityObserver,
+    DisabilityObserver,
+    PregnancyObserver,
+    MaternalDisordersObserver,
+    MaternalHemorrhageObserver,
+    HemoglobinObserver,
+    AnemiaObserver,
+)
 from vivarium_gates_iv_iron.components.pregnancy import Pregnancy

--- a/src/vivarium_gates_iv_iron/components/child.py
+++ b/src/vivarium_gates_iv_iron/components/child.py
@@ -9,14 +9,13 @@ from vivarium.framework.population import PopulationView, SimulantData
 from vivarium.framework.values import Pipeline
 from vivarium_cluster_tools import mkdir
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
+    BIRTH_WEIGHT,
+    GESTATIONAL_AGE,
     LBWSGDistribution,
 )
 
 from vivarium_gates_iv_iron import paths
 from vivarium_gates_iv_iron.constants import models
-
-BIRTH_WEIGHT = "birth_weight"
-GESTATIONAL_AGE = "gestational_age"
 
 
 class LBWSGExposure:

--- a/src/vivarium_gates_iv_iron/components/child.py
+++ b/src/vivarium_gates_iv_iron/components/child.py
@@ -1,0 +1,103 @@
+from typing import List, Union
+
+import pandas as pd
+from vivarium.framework.engine import Builder
+from vivarium.framework.values import Pipeline
+from vivarium.framework.time import Time
+from vivarium_public_health.risks import LBWSGDistribution
+from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
+    BIRTH_WEIGHT,
+    GESTATIONAL_AGE,
+)
+
+
+class LBWSGExposure:
+
+    randomness_stream_name = 'birth_propensities'
+    birth_weight_pipeline_name = 'birth_weight.exposure'
+    pregnancy_duration_pipeline_name = 'pregnancy_duration.exposure'
+    exposure_parameters_pipeline_name = (
+        "risk_factor.low_birth_weight_and_short_gestation.exposure_parameters"
+    )
+
+    configuration_defaults = {
+        "low_birth_weight_and_short_gestation": {
+            "exposure": "data",
+            "rebinned_exposed": [],
+            "category_thresholds": [],
+        }
+    }
+
+    def __init__(self):
+        self.lbwsg_exposure_distribution = LBWSGDistribution()
+        self._sub_components = [self.lbwsg_exposure_distribution]
+
+    def __repr__(self):
+        return "LBWSGExposure()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "lbwsg_exposure"
+
+    @property
+    def sub_components(self) -> List:
+        return self._sub_components
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder):
+        self.randomness = builder.randomness.get_stream(self.randomness_stream_name)
+        self.birth_weight = self._get_birth_weight_pipeline(builder)
+        self.pregnancy_duration = self._get_pregnancy_duration_pipeline(builder)
+
+    def _get_birth_weight_pipeline(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.birth_weight_pipeline_name,
+            self._birth_weight_pipeline_source,
+            requires_streams=[self.randomness_stream_name],
+            requires_values=[self.exposure_parameters_pipeline_name],
+        )
+
+    def _get_pregnancy_duration_pipeline(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.pregnancy_duration_pipeline_name,
+            self._pregnancy_duration_pipeline_source,
+            requires_streams=[self.randomness_stream_name],
+            requires_values=[self.exposure_parameters_pipeline_name],
+        )
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
+
+    def _birth_weight_pipeline_source(self, index: pd.Index) -> pd.Series:
+        birth_weight_propensity = self.randomness.get_draw(index, additional_key='birth_weight')
+        categorical_propensity = self.randomness.get_draw(index, additional_key='categorical')
+        birth_weight = self.lbwsg_exposure_distribution.single_axis_ppf(
+            BIRTH_WEIGHT, birth_weight_propensity, categorical_propensity
+        )
+        return birth_weight
+
+    def _pregnancy_duration_pipeline_source(self, index: pd.Index) -> pd.Series:
+        pregnancy_duration_propensity = self.randomness.get_draw(
+            index, additional_key='pregnancy_duration'
+        )
+        categorical_propensity = self.randomness.get_draw(index, additional_key='categorical')
+        pregnancy_duration = self.lbwsg_exposure_distribution.single_axis_ppf(
+            GESTATIONAL_AGE, pregnancy_duration_propensity, categorical_propensity
+        )
+        return pregnancy_duration
+
+
+def get_birth_date(
+    conception_date: Union[Time, pd.Series],
+    pregnancy_duration: Union[float, pd.Series]
+) -> Union[Time, pd.Series]:
+    return conception_date + pd.to_timedelta(pregnancy_duration, unit='d')

--- a/src/vivarium_gates_iv_iron/components/child.py
+++ b/src/vivarium_gates_iv_iron/components/child.py
@@ -170,6 +170,11 @@ class BirthObserver:
         self.seed = builder.configuration.randomness.random_seed
         self.scenario = builder.configuration.intervention.scenario
 
+        try:
+            self.output_path = Path(builder.configuration.output_data.child_path)
+        except:
+            self.output_path = paths.CHILD_DATA_OUTPUT_DIR
+
         self.pipelines = self.get_pipelines(builder)
         self.population_view = self.get_population_view(builder)
 
@@ -248,8 +253,8 @@ class BirthObserver:
         draws = pd.Series(self.input_draw, index=event.index, name="input_draw")
         seeds = pd.Series(self.seed, index=event.index, name="seed")
         scenarios = pd.Series(self.scenario, index=event.index, name="scenario")
-        output_data = pd.concat([draws, seeds, scenarios, self.births])
-        
+        output_data = pd.concat([draws, seeds, scenarios, self.births], axis=1)
+
         output_data.to_hdf(output_path, "child_birth_data")
         output_data.to_csv(csv_output_path)
 

--- a/src/vivarium_gates_iv_iron/components/child.py
+++ b/src/vivarium_gates_iv_iron/components/child.py
@@ -1,17 +1,19 @@
-from typing import List, Union
+from pathlib import Path
+from typing import List, Dict
 
 import pandas as pd
 from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView, SimulantData
 from vivarium.framework.values import Pipeline
-from vivarium.framework.time import Time
 from vivarium_public_health.risks import LBWSGDistribution
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
     BIRTH_WEIGHT,
     GESTATIONAL_AGE,
 )
 
-from vivarium_gates_iv_iron.constants.models import INVALID_OUTCOME
+from vivarium_gates_iv_iron import paths
+from vivarium_gates_iv_iron.constants import models
 
 
 class LBWSGExposure:
@@ -95,7 +97,9 @@ class LBWSGExposure:
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         self.population_view.update(
-            pd.Series(INVALID_OUTCOME, index=pop_data.index, name=self.sex_of_child_column_name)
+            pd.Series(
+                models.INVALID_OUTCOME, index=pop_data.index, name=self.sex_of_child_column_name
+            )
         )
 
     ##################################
@@ -121,8 +125,147 @@ class LBWSGExposure:
         return pregnancy_duration
 
 
-def get_birth_date(
-    conception_date: Union[Time, pd.Series],
-    pregnancy_duration: Union[float, pd.Series]
-) -> Union[Time, pd.Series]:
-    return conception_date + pd.to_timedelta(pregnancy_duration, unit='d')
+class BirthObserver:
+
+    pregnancy_status_column_name = "pregnancy_status"
+    pregnancy_duration_column_name = "pregnancy_duration"
+    pregnancy_state_change_column_name = "pregnancy_state_change_date"
+    child_sex_column_name = "sex_of_child"
+
+    birth_date_column_name = "birth_date"
+    sex_column_name = "sex"
+    birth_weight_column_name = "birth_weight"
+    gestational_age_column_name = "gestational_age"
+
+    birth_weight_pipeline_name = 'birth_weight.exposure'
+
+    def __repr__(self):
+        return "BirthObserver()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "birth_observer"
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.location = Path(builder.configuration.input_data.artifact_path).stem
+        self.input_draw = builder.configuration.input_data.input_draw_number
+        self.seed = builder.configuration.randomness.random_seed
+        self.scenario = builder.configuration.intervention.scenario
+
+        self.pipelines = self.get_pipelines(builder)
+        self.population_view = self.get_population_view(builder)
+
+        # todo add other attributes to be tracked as needed to both dataframes
+        self.ongoing_pregnancies = pd.DataFrame(
+            {
+                self.birth_date_column_name: [],
+                self.sex_column_name: [],
+                self.birth_weight_column_name: [],
+                self.gestational_age_column_name: [],
+            }
+        )
+        self.births = self.ongoing_pregnancies.copy()
+
+        self._register_simulant_initializer(builder)
+        self._register_collect_metrics_listener(builder)
+        self._register_simulation_end_listener(builder)
+
+    def get_pipelines(self, builder: Builder) -> Dict[str, Pipeline]:
+        return {
+            self.birth_weight_pipeline_name:
+                builder.value.get_value(self.birth_weight_pipeline_name),
+        }
+
+    def get_population_view(self, builder: Builder) -> PopulationView:
+        columns_required = [
+            self.pregnancy_status_column_name,
+            self.pregnancy_duration_column_name,
+            self.pregnancy_state_change_column_name,
+            self.child_sex_column_name,
+        ]
+        return builder.population.get_view(columns_required)
+
+    def _register_simulant_initializer(self, builder: Builder) -> None:
+        builder.population.initializes_simulants(
+            self.on_initialize_simulants,
+            requires_columns=[
+                self.child_sex_column_name,
+                self.pregnancy_status_column_name,
+                self.pregnancy_duration_column_name,
+                self.pregnancy_state_change_column_name,
+            ],
+            requires_values=[self.birth_weight_pipeline_name]
+        )
+
+    def _register_collect_metrics_listener(self, builder: Builder) -> None:
+        builder.event.register_listener("time_step", self.on_collect_metrics)
+
+    def _register_simulation_end_listener(self, builder: Builder) -> None:
+        builder.event.register_listener("simulation_end", self.write_output)
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        self._record_conceptions(self.population_view.get(pop_data.index))
+
+    def on_collect_metrics(self, event: Event) -> None:
+        pop = self.population_view.get(event.index)
+        self._record_births(pop, event)
+        self._record_conceptions(pop, event)
+
+    # noinspection PyUnusedLocal
+    def write_output(self, event: Event) -> None:
+        filename = f"{self.location}_{self.scenario}_{self.input_draw}_{self.seed}.hdf"
+        output_path = paths.CHILD_DATA_OUTPUT_DIR / filename
+        self.births.to_hdf(output_path, "child_birth_data")
+
+    ##################
+    # Helper methods #
+    ##################
+
+    def _record_births(self, pop: pd.DataFrame, event: Event) -> None:
+        new_births = self.ongoing_pregnancies[
+            self.ongoing_pregnancies[self.birth_date_column_name] <= event.time
+        ]
+
+        # this intersection removes all children whose mothers have passed away during pregnancy
+        live_births = new_births[new_births.index.intersection(pop.index)]
+
+        self.births = pd.concat([self.births, live_births], ignore_index=True)
+        self.ongoing_pregnancies = self.ongoing_pregnancies.drop(new_births.index)
+
+    def _record_conceptions(self, pop: pd.DataFrame, event: Event = None) -> None:
+        conception_mask = pop[self.pregnancy_status_column_name] == models.PREGNANT_STATE
+        if event is not None:
+            conception_mask &= (pop[self.pregnancy_state_change_column_name == event.time])
+
+        conception_index = pop[conception_mask].index
+        pregnancy_duration = pop.loc[conception_index, self.pregnancy_duration_column_name]
+
+        child_sex = (
+            pop.loc[conception_index, self.child_sex_column_name]
+            .rename(self.sex_column_name)
+        )
+        birth_date = (
+            pop.loc[conception_index, self.pregnancy_state_change_column_name] + pregnancy_duration
+        )
+        birth_weight = self.pipelines[self.birth_weight_pipeline_name](conception_index)
+        gestational_age = (
+            pregnancy_duration
+            .apply(lambda td: (td.days + td.seconds / (3600 * 24)) / 7.0)
+            .rename(self.gestational_age_column_name)
+        )
+
+        new_conceptions = pd.concat([child_sex, birth_date, birth_weight, gestational_age], axis=1)
+        self.ongoing_pregnancies = pd.concat([self.ongoing_pregnancies, new_conceptions])

--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -8,29 +8,252 @@ from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView
 from vivarium.framework.time import Time, get_time_stamp
-from vivarium.framework.values import Pipeline
+from vivarium.framework.values import Pipeline, list_combiner, rescale_post_processor, union_post_processor
 
-from vivarium_public_health.metrics import (
-    utilities,
-    MortalityObserver as MortalityObserver_,
-    DisabilityObserver as DisabilityObserver_,
-    DiseaseObserver as DiseaseObserver_,
-    CategoricalRiskObserver as CategoricalRiskObserver_,
-)
-from vivarium_public_health.metrics.utilities import (
+from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
+from vivarium_public_health.utilities import to_years
+
+from vivarium_gates_iv_iron.components.utilities import (
+    QueryString,
+    get_age_bins,
+    get_deaths,
     get_group_counts,
     get_output_template,
-    get_deaths,
+    get_person_time,
     get_state_person_time,
-    get_transition_count,
     get_years_lived_with_disability,
     get_years_of_life_lost,
     get_person_time,
     QueryString,
-    TransitionString,
 )
 
-from vivarium_gates_iv_iron.constants import models, results, data_keys, data_values
+
+from vivarium_gates_iv_iron.constants import data_keys, data_values, models, results
+
+
+class LegacyMortalityObserver:
+    """(From vivarium_public_health 0.10.15) An observer for cause-specific deaths, ylls, and total person time.
+
+    By default, this counts cause-specific deaths, years of life lost, and
+    total person time over the full course of the simulation. It can be
+    configured to bin these measures into age groups, sexes, and years
+    by setting the ``by_age``, ``by_sex``, and ``by_year`` flags, respectively.
+
+    In the model specification, your configuration for this component should
+    be specified as, e.g.:
+
+    .. code-block:: yaml
+
+        configuration:
+            metrics:
+                mortality:
+                    by_age: True
+                    by_year: False
+                    by_sex: True
+
+    """
+
+    configuration_defaults = {
+        "metrics": {
+            "mortality": {
+                "by_age": False,
+                "by_year": False,
+                "by_sex": False,
+            }
+        }
+    }
+
+    @property
+    def name(self):
+        return "mortality_observer"
+
+    def setup(self, builder):
+        self.config = builder.configuration.metrics.mortality
+        self.clock = builder.time.clock()
+        self.step_size = builder.time.step_size()
+        self.start_time = self.clock()
+        self.initial_pop_entrance_time = self.start_time - self.step_size()
+        self.age_bins = get_age_bins(builder)
+        diseases = builder.components.get_components_by_type(
+            (DiseaseState, RiskAttributableDisease)
+        )
+        self.causes = [c.state_id for c in diseases] + ["other_causes"]
+
+        life_expectancy_data = builder.data.load(
+            "population.theoretical_minimum_risk_life_expectancy"
+        )
+        self.life_expectancy = builder.lookup.build_table(
+            life_expectancy_data, key_columns=[], parameter_columns=["age"]
+        )
+
+        columns_required = [
+            "tracked",
+            "alive",
+            "entrance_time",
+            "exit_time",
+            "cause_of_death",
+            "years_of_life_lost",
+            "age",
+        ]
+        if self.config.by_sex:
+            columns_required += ["sex"]
+        self.population_view = builder.population.get_view(columns_required)
+
+        builder.value.register_value_modifier("metrics", self.metrics)
+
+    def metrics(self, index, metrics):
+        pop = self.population_view.get(index)
+        pop.loc[pop.exit_time.isnull(), "exit_time"] = self.clock()
+
+        person_time = get_person_time(
+            pop, self.config.to_dict(), self.start_time, self.clock(), self.age_bins
+        )
+        deaths = get_deaths(
+            pop,
+            self.config.to_dict(),
+            self.start_time,
+            self.clock(),
+            self.age_bins,
+            self.causes,
+        )
+        ylls = get_years_of_life_lost(
+            pop,
+            self.config.to_dict(),
+            self.start_time,
+            self.clock(),
+            self.age_bins,
+            self.life_expectancy,
+            self.causes,
+        )
+
+        metrics.update(person_time)
+        metrics.update(deaths)
+        metrics.update(ylls)
+
+        the_living = pop[(pop.alive == "alive") & pop.tracked]
+        the_dead = pop[pop.alive == "dead"]
+        metrics["years_of_life_lost"] = self.life_expectancy(the_dead.index).sum()
+        metrics["total_population_living"] = len(the_living)
+        metrics["total_population_dead"] = len(the_dead)
+
+        return metrics
+
+    def __repr__(self):
+        return "MortalityObserver()"
+
+
+class LegacyDisabilityObserver:
+    """(From vivarium_public_health v0.10.15) Counts years lived with disability.
+
+    By default, this counts both aggregate and cause-specific years lived
+    with disability over the full course of the simulation. It can be
+    configured to bin the cause-specific YLDs into age groups, sexes, and years
+    by setting the ``by_age``, ``by_sex``, and ``by_year`` flags, respectively.
+
+    In the model specification, your configuration for this component should
+    be specified as, e.g.:
+
+    .. code-block:: yaml
+
+        configuration:
+            metrics:
+                disability:
+                    by_age: True
+                    by_year: False
+                    by_sex: True
+
+    """
+
+    configuration_defaults = {
+        "metrics": {
+            "disability": {
+                "by_age": False,
+                "by_year": False,
+                "by_sex": False,
+            }
+        }
+    }
+
+    @property
+    def name(self):
+        return "disability_observer"
+
+    def setup(self, builder):
+        self.config = builder.configuration.metrics.disability
+        self.age_bins = get_age_bins(builder)
+        self.clock = builder.time.clock()
+        self.step_size = builder.time.step_size()
+        self.causes = [
+            c.state_id
+            for c in builder.components.get_components_by_type(
+                (DiseaseState, RiskAttributableDisease)
+            )
+        ]
+        self.years_lived_with_disability = Counter()
+        self.disability_weight_pipelines = {
+            cause: builder.value.get_value(f"{cause}.disability_weight")
+            for cause in self.causes
+        }
+
+        self.disability_weight = builder.value.register_value_producer(
+            "disability_weight",
+            source=lambda index: [pd.Series(0.0, index=index)],
+            preferred_combiner=list_combiner,
+            preferred_post_processor=_disability_post_processor,
+        )
+
+        columns_required = ["tracked", "alive", "years_lived_with_disability"]
+        if self.config.by_age:
+            columns_required += ["age"]
+        if self.config.by_sex:
+            columns_required += ["sex"]
+        self.population_view = builder.population.get_view(columns_required)
+        builder.population.initializes_simulants(
+            self.initialize_disability, creates_columns=["years_lived_with_disability"]
+        )
+        # FIXME: The state table is modified before the clock advances.
+        # In order to get an accurate representation of person time we need to look at
+        # the state table before anything happens.
+        builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
+        builder.value.register_value_modifier("metrics", modifier=self.metrics)
+
+    def initialize_disability(self, pop_data):
+        self.population_view.update(
+            pd.Series(0.0, index=pop_data.index, name="years_lived_with_disability")
+        )
+
+    def on_time_step_prepare(self, event):
+        pop = self.population_view.get(
+            event.index, query='tracked == True and alive == "alive"'
+        )
+        ylds_this_step = get_years_lived_with_disability(
+            pop,
+            self.config.to_dict(),
+            self.clock().year,
+            self.step_size(),
+            self.age_bins,
+            self.disability_weight_pipelines,
+            self.causes,
+        )
+        self.years_lived_with_disability.update(ylds_this_step)
+
+        pop.loc[:, "years_lived_with_disability"] += self.disability_weight(pop.index)
+        self.population_view.update(pop)
+
+    def metrics(self, index, metrics):
+        total_ylds = self.population_view.get(index)[
+            "years_lived_with_disability"
+        ].sum()
+        metrics["years_lived_with_disability"] = total_ylds
+        metrics.update(self.years_lived_with_disability)
+        return metrics
+
+    def __repr__(self):
+        return "DisabilityObserver()"
+
+
+def _disability_post_processor(value, step_size):
+    return rescale_post_processor(union_post_processor(value, step_size), step_size)
 
 
 class ResultsStratifier:
@@ -208,7 +431,7 @@ class ResultsStratifier:
         return measure_data
 
 
-class MortalityObserver(MortalityObserver_):
+class MortalityObserver(LegacyMortalityObserver):
     def __init__(self):
         super().__init__()
         self.stratifier = ResultsStratifier(self.name)
@@ -256,7 +479,7 @@ class MortalityObserver(MortalityObserver_):
         return metrics
 
 
-class DisabilityObserver(DisabilityObserver_):
+class DisabilityObserver(LegacyDisabilityObserver):
     def __init__(self):
         super().__init__()
         self.stratifier = ResultsStratifier(self.name)
@@ -329,7 +552,7 @@ class PregnancyObserver:
         self.clock = builder.time.clock()
         self.configuration = builder.configuration.metrics.pregnancy
         self.start_time = get_time_stamp(builder.configuration.time.start)
-        self.age_bins = utilities.get_age_bins(builder)
+        self.age_bins = get_age_bins(builder)
         self.person_time = Counter()
         self.counts = Counter()
 
@@ -383,7 +606,7 @@ class PregnancyObserver:
                 base_filter,
                 base_key, config,
                 age_bins,
-                aggregate=lambda x: len(x) * utilities.to_years(step_size)
+                aggregate=lambda x: len(x) * to_years(step_size),
             )
             return person_time
 
@@ -495,7 +718,7 @@ class MaternalDisordersObserver:
         self.configuration = builder.configuration.metrics.maternal_disorders
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.step_size = builder.time.step_size()
-        self.age_bins = utilities.get_age_bins(builder)
+        self.age_bins = get_age_bins(builder)
         self.deaths = Counter()
         self.counts = Counter()
         self.ylds = Counter()
@@ -629,7 +852,7 @@ class MaternalHemorrhageObserver:
         self.configuration = builder.configuration.metrics.maternal_hemorrhage
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.step_size = builder.time.step_size()
-        self.age_bins = utilities.get_age_bins(builder)
+        self.age_bins = get_age_bins(builder)
         self.person_time = Counter()
         self.counts = Counter()
 
@@ -654,12 +877,17 @@ class MaternalHemorrhageObserver:
 
         # Accrue all counts and time to the current year
         for state in models.MATERNAL_HEMORRHAGE_STATES:
-             # Accrue all counts and time to the current year
-             state_person_time_this_step = utilities.get_state_person_time(
-                 pop, self.configuration, 'maternal_hemorrhage', state, self.clock().year,
-                 event.step_size, self.age_bins
-             )
-             self.person_time.update(state_person_time_this_step)
+            # Accrue all counts and time to the current year
+            state_person_time_this_step = get_state_person_time(
+                pop,
+                self.configuration,
+                "maternal_hemorrhage",
+                state,
+                self.clock().year,
+                event.step_size,
+                self.age_bins,
+            )
+            self.person_time.update(state_person_time_this_step)
 
     def on_collect_metrics(self, event: Event):
         counts_this_step = {}
@@ -727,7 +955,7 @@ class HemoglobinObserver:
     def setup(self, builder: Builder) -> None:
         self.configuration = builder.configuration.metrics.hemoglobin
         self.hemoglobin = builder.value.get_value("hemoglobin.exposure")
-        self.age_bins = utilities.get_age_bins(builder)
+        self.age_bins = get_age_bins(builder)
         self.exposure = Counter()
 
         columns_required = ["alive", "pregnancy_status", "maternal_hemorrhage"]
@@ -808,7 +1036,7 @@ class AnemiaObserver:
         self.clock = builder.time.clock()
         self.configuration = builder.configuration.metrics.anemia
         self.anemia_levels = builder.value.get_value("anemia_levels")
-        self.age_bins = utilities.get_age_bins(builder)
+        self.age_bins = get_age_bins(builder)
         self.person_time = Counter()
 
         columns_required = ["alive", "pregnancy_status", "maternal_hemorrhage"]
@@ -852,7 +1080,7 @@ class AnemiaObserver:
                 base_key,
                 config,
                 age_bins,
-                aggregate=lambda x: len(x) * utilities.to_years(step_size),
+                aggregate=lambda x: len(x) * to_years(step_size),
             )
             return person_time
 

--- a/src/vivarium_gates_iv_iron/components/utilities.py
+++ b/src/vivarium_gates_iv_iron/components/utilities.py
@@ -1,0 +1,607 @@
+from collections import ChainMap
+from string import Template
+from typing import Union, List, Tuple, Dict, Callable
+
+import numpy as np
+import pandas as pd
+from vivarium.framework.lookup import LookupTable
+from vivarium.framework.values import Pipeline
+
+from vivarium_public_health.utilities import to_years
+
+_MIN_AGE = 0.
+_MAX_AGE = 150.
+_MIN_YEAR = 1900
+_MAX_YEAR = 2100
+
+"""
+This file contains classes and methods used in most of the observers pre-LBWSG, preserved from Vivarium Public 
+Health 0.10.15 metrics/utilities.py.
+"""
+
+
+
+class QueryString(str):
+    """Convenience string that forms logical conjunctions using addition.
+
+    This class is meant to be used to create a logical statement for
+    use with pandas ``query`` functions. It hides away the management
+    of conjunctions and the fence posting problems that management creates.
+
+    Examples
+    --------
+    >>> from vivarium_gates_iv_iron.components.utilities import QueryString
+    >>> s = QueryString('')
+    >>> s
+    ''
+    >>> s + ''
+    ''
+    >>> s + 'abc'
+    'abc'
+    >>> s += 'abc'
+    >>> s + 'def'
+    'abc and def'
+
+    """
+    def __add__(self, other: Union[str, 'QueryString']) -> 'QueryString':
+        if self:
+            if other:
+                return QueryString(str(self) + ' and ' + str(other))
+            else:
+                return self
+        else:
+            return QueryString(other)
+
+    def __radd__(self, other: Union[str, 'QueryString']) -> 'QueryString':
+        return QueryString(other) + self
+
+
+class SubstituteString(str):
+    """Normal string plus a no-op substitute method.
+
+    Meant to be used with the OutputTemplate.
+
+    """
+    def substitute(self, *_, **__) -> 'SubstituteString':
+        """No-op method for consistency with OutputTemplate."""
+        return self
+
+
+class OutputTemplate(Template):
+    """Output string template that enforces standardized formatting."""
+    @staticmethod
+    def format_template_value(value):
+        """Formatting helper method for substituting values into a template."""
+        return str(value).replace(' ', '_').lower()
+
+    @staticmethod
+    def get_mapping(*args, **kws):
+        """Gets a consistent mapping from args passed to substitute."""
+        # This is copied directly from the first part of Template.substitute
+        if not args:
+            raise TypeError("descriptor 'substitute' of 'Template' object "
+                            "needs an argument")
+        self, *args = args  # allow the "self" keyword be passed
+        if len(args) > 1:
+            raise TypeError('Too many positional arguments')
+        if not args:
+            mapping = dict(kws)
+        elif kws:
+            mapping = ChainMap(kws, args[0])
+        else:
+            mapping = args[0]
+        return self, mapping
+
+    def substitute(*args, **kws) -> Union[SubstituteString, 'OutputTemplate']:
+        """Substitutes provided values into the template.
+
+        Users are allowed to pass any dictionary like object whose keys match
+        placeholders in the template. Alternatively, they can provide
+        keyword arguments where the keywords are the placeholders. If both
+        are provided, the keywords take precedence.
+
+        Returns
+        -------
+        Union[SubstituteString, OutputTemplate]
+            Another output template with the provided values substituted in
+            to the template placeholders if any placeholders remain,
+            otherwise a completed ``SubstituteString``.
+        """
+        self, mapping = OutputTemplate.get_mapping(*args, **kws)
+        mapping = {key: self.format_template_value(value) for key, value in mapping.items()}
+        try:
+            return SubstituteString(super(OutputTemplate, self).substitute(mapping))
+        except KeyError:
+            return OutputTemplate(super(OutputTemplate, self).safe_substitute(mapping))
+
+    def safe_substitute(*args, **kws):
+        """Alias to OutputTemplate.substitute."""
+        self, mapping = OutputTemplate.get_mapping(*args, **kws)
+        return self.substitute(mapping)
+
+    def __repr__(self):
+        return super(OutputTemplate, self).safe_substitute()
+
+
+def get_age_bins(builder) -> pd.DataFrame:
+    """Retrieves age bins relevant to the current simulation.
+
+    Parameters
+    ----------
+    builder
+        The simulation builder.
+
+    Returns
+    -------
+        DataFrame with columns ``age_group_name``, ``age_start``,
+        and ``age_end``.
+
+    """
+    age_bins = builder.data.load('population.age_bins')
+
+    # Works based on the fact that currently only models with age_start = 0 can include fertility
+    age_start = builder.configuration.population.age_start
+    min_bin_start = age_bins.age_start[np.asscalar(np.digitize(age_start, age_bins.age_end))]
+    age_bins = age_bins[age_bins.age_start >= min_bin_start]
+    age_bins.loc[age_bins.age_start < age_start, 'age_start'] = age_start
+
+    exit_age = builder.configuration.population.exit_age
+    if exit_age:
+        age_bins = age_bins[age_bins.age_start < exit_age]
+        age_bins.loc[age_bins.age_end > exit_age, 'age_end'] = exit_age
+    return age_bins
+
+def get_time_iterable(config: Dict[str, bool],
+                      sim_start: pd.Timestamp,
+                      sim_end: pd.Timestamp) -> List[Tuple[str, Tuple[pd.Timestamp, pd.Timestamp]]]:
+    """Constructs an iterable for time bins.
+
+    The constructed iterable are based on configuration for the observer
+    component.
+
+    Parameters
+    ----------
+    config
+        A mapping with 'by_year' and a boolean value indicating whether
+        the observer is binning data by year.
+    sim_start
+        The time the simulation starts.
+    sim_end
+        The time the simulation ends.
+
+    Returns
+    -------
+    List[Tuple[str, Tuple[pandas.Timestamp, pandas.Timestamp]]]
+        Iterable for the time groups partially defining the bins
+        for the observers.
+
+    """
+    if config['by_year']:
+        time_spans = [(year, (pd.Timestamp(f'1-1-{year}'), pd.Timestamp(f'1-1-{year + 1}')))
+                      for year in range(sim_start.year, sim_end.year + 1)]
+    else:
+        time_spans = [('all_years', (pd.Timestamp(f'1-1-{_MIN_YEAR}'), pd.Timestamp(f'1-1-{_MAX_YEAR}')))]
+    return time_spans
+
+
+def get_deaths(pop: pd.DataFrame, config: Dict[str, bool], sim_start: pd.Timestamp,
+               sim_end: pd.Timestamp, age_bins: pd.DataFrame, causes: List[str]) -> Dict[str, int]:
+    """Counts the number of deaths by cause.
+
+    Parameters
+    ----------
+    pop
+        The population dataframe to be counted. It must contain sufficient
+        columns for any necessary filtering (e.g. the ``age`` column if
+        filtering by age).
+    config
+        A dict with ``by_age``, ``by_sex``, and ``by_year`` keys and
+        boolean values.
+    sim_start
+        The simulation start time.
+    sim_end
+        The simulation end time.
+    age_bins
+        A dataframe with ``age_start`` and ``age_end`` columns.
+    causes
+        List of causes present in the simulation.
+
+    Returns
+    -------
+    Dict[str, int]
+        A dictionary of output_key, death_count pairs where the output_key
+        represents a particular demographic subgroup.
+
+    """
+    base_filter = QueryString('alive == "dead" and cause_of_death == "death_due_to_{cause}"')
+    base_key = get_output_template(**config)
+    pop = clean_cause_of_death(pop)
+
+    time_spans = get_time_iterable(config, sim_start, sim_end)
+
+    deaths = {}
+    for year, (t_start, t_end) in time_spans:
+        died_in_span = pop[(t_start <= pop.exit_time) & (pop.exit_time < t_end)]
+        for cause in causes:
+            cause_year_key = base_key.substitute(measure=f'death_due_to_{cause}', year=year)
+            cause_filter = base_filter.format(cause=cause)
+            group_deaths = get_group_counts(died_in_span, cause_filter, cause_year_key, config, age_bins)
+            deaths.update(group_deaths)
+    return deaths
+
+def get_group_counts(pop: pd.DataFrame,
+                     base_filter: str,
+                     base_key: OutputTemplate,
+                     config: Dict[str, bool],
+                     age_bins: pd.DataFrame,
+                     aggregate: Callable[[pd.DataFrame], Union[int, float]] = len
+                     ) -> Dict[Union[SubstituteString, OutputTemplate], Union[int, float]]:
+    """Gets a count of people in a custom subgroup.
+
+    The user is responsible for providing a default filter (e.g. only alive
+    people, or people susceptible to a particular disease).  Demographic
+    filters will be applied based on standardized configuration.
+
+    Parameters
+    ----------
+    pop
+        The population dataframe to be counted.  It must contain sufficient
+        columns for any necessary filtering (e.g. the ``age`` column if
+        filtering by age).
+    base_filter
+        A base filter term (e.g.: alive, susceptible to a particular disease)
+        formatted to work with the query method of the provided population
+        dataframe.
+    base_key
+        A template string with replaceable fields corresponding to the
+        requested filters.
+    config
+        A dict with ``by_age`` and ``by_sex`` keys and boolean values.
+    age_bins
+        A dataframe with ``age_start`` and ``age_end`` columns.
+    aggregate
+        Transformation used to produce the aggregate.
+
+    Returns
+    -------
+    Dict[Union[SubstituteString, OutputTemplate], Union[int, float]]
+        A dictionary of output_key, count pairs where the output key is a
+        string or template representing the sub groups.
+    """
+    age_sex_filter, (ages, sexes) = get_age_sex_filter_and_iterables(config, age_bins)
+    base_filter += age_sex_filter
+
+    group_counts = {}
+
+    for group, age_group in ages:
+        start, end = age_group.age_start, age_group.age_end
+        for sex in sexes:
+            filter_kwargs = {'age_start': start, 'age_end': end, 'sex': sex, 'age_group': group}
+            group_key = base_key.substitute(**filter_kwargs)
+            group_filter = base_filter.format(**filter_kwargs)
+            in_group = pop.query(group_filter) if group_filter and not pop.empty else pop
+
+            group_counts[group_key] = aggregate(in_group)
+
+    return group_counts
+
+def get_output_template(by_age: bool, by_sex: bool, by_year: bool, **_) -> OutputTemplate:
+    """Gets a template string for output metrics.
+
+    The template string should be filled in using filter criteria for
+    measure, age, sex, and year in the observer using this function.
+
+    Parameters
+    ----------
+    by_age
+        Whether the template should include age criteria.
+    by_sex
+        Whether the template should include sex criteria.
+    by_year
+        Whether the template should include year criteria.
+
+    Returns
+    -------
+    OutputTemplate
+        A template string with measure and possibly additional criteria.
+
+    """
+    template = '${measure}'
+    if by_year:
+        template += '_in_${year}'
+    if by_sex:
+        template += '_among_${sex}'
+    if by_age:
+        template += '_in_age_group_${age_group}'
+    return OutputTemplate(template)
+
+def get_person_time(pop: pd.DataFrame, config: Dict[str, bool], sim_start: pd.Timestamp,
+                    sim_end: pd.Timestamp, age_bins: pd.DataFrame) -> Dict[str, float]:
+    base_key = get_output_template(**config).substitute(measure='person_time')
+    base_filter = QueryString("")
+    time_spans = get_time_iterable(config, sim_start, sim_end)
+
+    person_time = {}
+    for year, (t_start, t_end) in time_spans:
+        year_key = base_key.substitute(year=year)
+        lived_in_span = get_lived_in_span(pop, t_start, t_end)
+        person_time_in_span = get_person_time_in_span(lived_in_span, base_filter, year_key, config, age_bins)
+        person_time.update(person_time_in_span)
+    return person_time
+
+
+def get_lived_in_span(pop: pd.DataFrame, t_start: pd.Timestamp, t_end: pd.Timestamp) -> pd.DataFrame:
+    """Gets a subset of the population that lived in the time span.
+
+    Parameters
+    ----------
+    pop
+        A table representing the population with columns for 'entrance_time',
+        'exit_time' and 'age'.
+    t_start
+        The date and time at the start of the span.
+    t_end
+        The date and time at the end of the span.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A table representing the population who lived some amount of time
+        within the time span with all columns provided in the original
+        table and additional columns 'age_at_span_start' and 'age_at_span_end'
+        indicating the age of the individual at the start and end of the time
+        span, respectively. 'age_at_span_start' will never be lower than the
+        age at the simulant's entrance time and 'age_at_span_end' will never
+        be greater than the age at the simulant's exit time.
+
+    """
+    lived_in_span = pop.loc[(t_start < pop['exit_time']) & (pop['entrance_time'] < t_end)]
+
+    span_entrance_time = lived_in_span.entrance_time.copy()
+    span_entrance_time.loc[t_start > span_entrance_time] = t_start
+    span_exit_time = lived_in_span.exit_time.copy()
+    span_exit_time.loc[t_end < span_exit_time] = t_end
+
+    lived_in_span.loc[:, 'age_at_span_end'] = lived_in_span.age - to_years(lived_in_span.exit_time
+                                                                           - span_exit_time)
+    lived_in_span.loc[:, 'age_at_span_start'] = lived_in_span.age - to_years(lived_in_span.exit_time
+                                                                             - span_entrance_time)
+    return lived_in_span
+
+
+def get_age_sex_filter_and_iterables(config: Dict[str, bool],
+                                     age_bins: pd.DataFrame,
+                                     in_span: bool = False) -> Tuple[QueryString,
+                                                                     Tuple[List[Tuple[str, pd.Series]], List[str]]]:
+    """Constructs a filter and a set of iterables for age and sex.
+
+    The constructed filter and iterables are based on configuration for the
+    observer component.
+
+    Parameters
+    ----------
+    config
+        A mapping with 'by_age' and 'by_sex' keys and boolean values
+        indicating whether the observer is binning data by the respective
+        categories.
+    age_bins
+        A table containing bin names and bin edges.
+    in_span
+        Whether the filter for age corresponds to living through an age
+        group in a time span or uses a point estimate of age at a particular
+        point in time.
+
+    Returns
+    -------
+    QueryString
+        A filter on age and sex for use with DataFrame.query
+    Tuple[List[Tuple[str, pd.Series]], List[str]]
+        Iterables for the age and sex groups partially defining the bins
+        for the observers.
+
+    """
+    age_sex_filter = QueryString("")
+    if config['by_age']:
+        ages = list(age_bins.set_index('age_group_name').iterrows())
+        if in_span:
+            age_sex_filter += '{age_start} < age_at_span_end and age_at_span_start < {age_end}'
+        else:
+            age_sex_filter += '{age_start} <= age and age < {age_end}'
+    else:
+        ages = [('all_ages', pd.Series({'age_start': _MIN_AGE, 'age_end': _MAX_AGE}))]
+
+    if config['by_sex']:
+        sexes = ['Male', 'Female']
+        age_sex_filter += 'sex == "{sex}"'
+    else:
+        sexes = ['Both']
+
+    return age_sex_filter, (ages, sexes)
+
+
+
+def get_person_time_in_span(lived_in_span: pd.DataFrame, base_filter: QueryString,
+                            span_key: OutputTemplate, config: Dict[str, bool],
+                            age_bins: pd.DataFrame) -> Dict[Union[SubstituteString, OutputTemplate], float]:
+    """Counts the amount of person time lived in a particular time span.
+
+    Parameters
+    ----------
+    lived_in_span
+        A table representing the subset of the population who lived in a
+        particular time span. Must have columns for 'age_at_span_start' and
+        'age_at_span_end'.
+    base_filter
+        A base filter term (e.g.: alive, susceptible to a particular disease)
+        formatted to work with the query method of the provided population
+        dataframe.
+    span_key
+        A template string with replaceable fields corresponding to the
+        requested filters.
+    config
+        A dict with ``by_age`` and ``by_sex`` keys and boolean values.
+    age_bins
+        A dataframe with ``age_start`` and ``age_end`` columns.
+
+    Returns
+    -------
+    Dict[Union[SubstituteString, OutputTemplate], float]
+        A dictionary of output_key, person_time pairs where the output key
+        corresponds to a particular demographic group.
+    """
+    person_time = {}
+    age_sex_filter, (ages, sexes) = get_age_sex_filter_and_iterables(config, age_bins, in_span=True)
+    base_filter += age_sex_filter
+
+    for group, age_bin in ages:
+        a_start, a_end = age_bin.age_start, age_bin.age_end
+        for sex in sexes:
+            filter_kwargs = {'sex': sex, 'age_start': a_start,
+                             'age_end': a_end, 'age_group': group}
+
+            key = span_key.substitute(**filter_kwargs)
+            group_filter = base_filter.format(**filter_kwargs)
+
+            in_group = lived_in_span.query(group_filter) if group_filter else lived_in_span.copy()
+            age_start = np.maximum(in_group.age_at_span_start, a_start)
+            age_end = np.minimum(in_group.age_at_span_end, a_end)
+
+            person_time[key] = (age_end - age_start).sum()
+
+    return person_time
+
+
+
+def get_state_person_time(pop: pd.DataFrame, config: Dict[str, bool],
+                          state_machine: str, state: str, current_year: Union[str, int],
+                          step_size: pd.Timedelta, age_bins: pd.DataFrame) -> Dict[str, float]:
+    """Custom person time getter that handles state column name assumptions"""
+    base_key = get_output_template(**config).substitute(measure=f'{state}_person_time',
+                                                        year=current_year)
+    base_filter = QueryString(f'alive == "alive" and {state_machine} == "{state}"')
+    person_time = get_group_counts(pop, base_filter, base_key, config, age_bins,
+                                   aggregate=lambda x: len(x) * to_years(step_size))
+    return person_time
+
+
+def get_years_of_life_lost(pop: pd.DataFrame,
+                           config: Dict[str, bool],
+                           sim_start: pd.Timestamp,
+                           sim_end: pd.Timestamp,
+                           age_bins: pd.DataFrame,
+                           life_expectancy: LookupTable,
+                           causes: List[str]) -> Dict[str, float]:
+    """Counts the years of life lost by cause.
+
+    Parameters
+    ----------
+    pop
+        The population dataframe to be counted. It must contain sufficient
+        columns for any necessary filtering (e.g. the ``age`` column if
+        filtering by age).
+    config
+        A dict with ``by_age``, ``by_sex``, and ``by_year`` keys and
+        boolean values.
+    sim_start
+        The simulation start time.
+    sim_end
+        The simulation end time.
+    age_bins
+        A dataframe with ``age_start`` and ``age_end`` columns.
+    life_expectancy
+        A lookup table that takes in a pandas index and returns the life
+        expectancy of the each individual represented by the index.
+    causes
+        List of causes present in the simulation.
+
+    Returns
+    -------
+    Dict[str, float]
+        A dictionary of output_key, yll_count pairs where the output_key
+        represents a particular demographic subgroup.
+
+    """
+    base_filter = QueryString('alive == "dead" and cause_of_death == "death_due_to_{cause}"')
+    base_key = get_output_template(**config)
+    pop = clean_cause_of_death(pop)
+
+    time_spans = get_time_iterable(config, sim_start, sim_end)
+
+    years_of_life_lost = {}
+    for year, (t_start, t_end) in time_spans:
+        died_in_span = pop[(t_start <= pop.exit_time) & (pop.exit_time < t_end)]
+        for cause in causes:
+            cause_year_key = base_key.substitute(measure=f'ylls_due_to_{cause}', year=year)
+            cause_filter = base_filter.format(cause=cause)
+            group_ylls = get_group_counts(died_in_span, cause_filter, cause_year_key, config, age_bins,
+                                          aggregate=lambda subgroup: sum(life_expectancy(subgroup.index)))
+            years_of_life_lost.update(group_ylls)
+    return years_of_life_lost
+
+
+def get_years_lived_with_disability(pop: pd.DataFrame,
+                                    config: Dict[str, bool],
+                                    current_year: int,
+                                    step_size: pd.Timedelta,
+                                    age_bins: pd.DataFrame,
+                                    disability_weights: Dict[str, Pipeline],
+                                    causes: List[str]) -> Dict[str, float]:
+    """Counts the years lived with disability by cause in the time step.
+
+    Parameters
+    ----------
+    pop
+        The population dataframe to be counted. It must contain sufficient
+        columns for any necessary filtering (e.g. the ``age`` column if
+        filtering by age).
+    config
+        A dict with ``by_age``, ``by_sex``, and ``by_year`` keys and
+        boolean values.
+    current_year
+        The current year in the simulation.
+    step_size
+        The size of the current time step.
+    age_bins
+        A dataframe with ``age_start`` and ``age_end`` columns.
+    disability_weights
+        A mapping between causes and their disability weight pipelines.
+    causes
+        List of causes present in the simulation.
+
+    Returns
+    -------
+    Dict[str, float]
+        A dictionary of output_key, yld_count pairs where the output_key
+        represents a particular demographic subgroup.
+
+    """
+    base_key = get_output_template(**config).substitute(year=current_year)
+    base_filter = QueryString('alive == "alive"')
+
+    years_lived_with_disability = {}
+    for cause in causes:
+        cause_key = base_key.substitute(measure=f'ylds_due_to_{cause}')
+
+        def count_ylds(sub_group):
+            """Counts ylds attributable to a cause in the time step."""
+            return sum(disability_weights[cause](sub_group.index) * to_years(step_size))
+
+        group_ylds = get_group_counts(pop, base_filter, cause_key, config, age_bins, aggregate=count_ylds)
+        years_lived_with_disability.update(group_ylds)
+
+    return years_lived_with_disability
+
+
+def clean_cause_of_death(pop: pd.DataFrame) -> pd.DataFrame:
+    """Standardizes cause of death names to all read ``death_due_to_cause``."""
+
+    def _clean(cod: str) -> str:
+        if 'death' in cod or 'dead' in cod:
+            pass
+        else:
+            cod = f'death_due_to_{cod}'
+        return cod
+
+    pop.cause_of_death = pop.cause_of_death.apply(_clean)
+    return pop
+

--- a/src/vivarium_gates_iv_iron/data/loader.py
+++ b/src/vivarium_gates_iv_iron/data/loader.py
@@ -305,7 +305,10 @@ def load_lbwsg_exposure(key: str, location: str) -> pd.DataFrame:
     data = data[data['year_id'] == 2019].drop(columns='year_id')
     data = utilities.process_exposure(data, key, entity, location, metadata.GBD_2019_ROUND_ID,
                                       metadata.AGE_GROUP.GBD_2019_LBWSG_EXPOSURE | metadata.AGE_GROUP.GBD_2020)
-    data = data[data.index.get_level_values('year_start') == 2019]
+    data = data[
+        (data.index.get_level_values('year_start') == 2019)
+        & (data.index.get_level_values('age_end') == 0.0)
+    ]
     return data
 
 

--- a/src/vivarium_gates_iv_iron/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/branches/scenarios.yaml
@@ -2,6 +2,5 @@ input_draw_count: 66
 random_seed_count: 10
 
 branches:
-# TODO change to name of intervention
-  - placeholder_branch_name:
+  - intervention:
       scenario: ['baseline']

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -7,13 +7,13 @@ components:
         - Pregnancy()
         - LBWSGExposure()
 
-#        - DisabilityObserver()
-#        - MortalityObserver()
-#        - PregnancyObserver()
-#        - MaternalDisordersObserver()
-#        - MaternalHemorrhageObserver()
-#        - HemoglobinObserver()
-#        - AnemiaObserver()
+        - DisabilityObserver()
+        - MortalityObserver()
+        - PregnancyObserver()
+        - MaternalDisordersObserver()
+        - MaternalHemorrhageObserver()
+        - HemoglobinObserver()
+        - AnemiaObserver()
         - BirthObserver()
 
 configuration:

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -22,7 +22,7 @@ configuration:
         location: 'South Asia'
         artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_iv_iron/south_asia.hdf'
 #    output_data:
-#        child_path: "/Users/mkappel/viv_out"
+#        child_path: "/Users/mkappel/viv_out/child_data"
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -5,6 +5,8 @@ components:
 
     vivarium_gates_iv_iron.components:
         - Pregnancy()
+        - LBWSGExposure()
+
         - DisabilityObserver()
         - MortalityObserver()
         - PregnancyObserver()

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -21,6 +21,8 @@ configuration:
         input_draw_number: 0
         location: 'South Asia'
         artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_iv_iron/south_asia.hdf'
+#    output_data:
+#        child_path: "/Users/mkappel/viv_out"
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -14,6 +14,7 @@ components:
 #        - MaternalHemorrhageObserver()
 #        - HemoglobinObserver()
 #        - AnemiaObserver()
+        - BirthObserver()
 
 configuration:
     input_data:
@@ -42,6 +43,9 @@ configuration:
         age_start: 7
         age_end: 54
         pregnant_lactating_women: False
+
+    intervention:
+        scenario: "baseline"
 
     lbwsg_distribution:
         sex_column: "sex_of_child"

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -7,13 +7,13 @@ components:
         - Pregnancy()
         - LBWSGExposure()
 
-        - DisabilityObserver()
-        - MortalityObserver()
-        - PregnancyObserver()
-        - MaternalDisordersObserver()
-        - MaternalHemorrhageObserver()
-        - HemoglobinObserver()
-        - AnemiaObserver()
+#        - DisabilityObserver()
+#        - MortalityObserver()
+#        - PregnancyObserver()
+#        - MaternalDisordersObserver()
+#        - MaternalHemorrhageObserver()
+#        - HemoglobinObserver()
+#        - AnemiaObserver()
 
 configuration:
     input_data:
@@ -42,6 +42,9 @@ configuration:
         age_start: 7
         age_end: 54
         pregnant_lactating_women: False
+
+    lbwsg_distribution:
+        sex_column: "sex_of_child"
 
     metrics:
         disability:

--- a/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
@@ -14,6 +14,7 @@ components:
         - MaternalHemorrhageObserver()
         - HemoglobinObserver()
         - AnemiaObserver()
+        - BirthObserver()
 
 configuration:
     input_data:
@@ -42,6 +43,9 @@ configuration:
         age_start: 7
         age_end: 54
         pregnant_lactating_women: False
+
+    intervention:
+        scenario: "baseline"
 
     lbwsg_distribution:
         sex_column: "sex_of_child"

--- a/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
@@ -5,6 +5,8 @@ components:
 
     vivarium_gates_iv_iron.components:
         - Pregnancy()
+        - LBWSGExposure()
+
         - DisabilityObserver()
         - MortalityObserver()
         - PregnancyObserver()

--- a/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/sub-saharan_africa.yaml
@@ -43,6 +43,9 @@ configuration:
         age_end: 54
         pregnant_lactating_women: False
 
+    lbwsg_distribution:
+        sex_column: "sex_of_child"
+
     metrics:
         disability:
             by_age: True

--- a/src/vivarium_gates_iv_iron/paths.py
+++ b/src/vivarium_gates_iv_iron/paths.py
@@ -11,3 +11,4 @@ RESULTS_ROOT = Path(f"/share/costeffectiveness/results/{metadata.PROJECT_NAME}/"
 
 # todo fix a better output location
 CHILD_DATA_OUTPUT_DIR = RESULTS_ROOT / "child_data"
+

--- a/src/vivarium_gates_iv_iron/paths.py
+++ b/src/vivarium_gates_iv_iron/paths.py
@@ -8,3 +8,6 @@ BASE_DIR = Path(vivarium_gates_iv_iron.__file__).resolve().parent
 ARTIFACT_ROOT = Path(f"/share/costeffectiveness/artifacts/{metadata.PROJECT_NAME}/")
 MODEL_SPEC_DIR = BASE_DIR / "model_specifications"
 RESULTS_ROOT = Path(f"/share/costeffectiveness/results/{metadata.PROJECT_NAME}/")
+
+# todo fix a better output location
+CHILD_DATA_OUTPUT_DIR = RESULTS_ROOT / "child_data"

--- a/src/vivarium_gates_iv_iron/paths.py
+++ b/src/vivarium_gates_iv_iron/paths.py
@@ -10,5 +10,6 @@ MODEL_SPEC_DIR = BASE_DIR / "model_specifications"
 RESULTS_ROOT = Path(f"/share/costeffectiveness/results/{metadata.PROJECT_NAME}/")
 
 # todo fix a better output location
-CHILD_DATA_OUTPUT_DIR = RESULTS_ROOT / "child_data"
+#CHILD_DATA_OUTPUT_DIR = RESULTS_ROOT / "child_data"
+CHILD_DATA_OUTPUT_DIR = Path("/Users/mkappel/viv_out") / "child_data"
 

--- a/src/vivarium_gates_iv_iron/paths.py
+++ b/src/vivarium_gates_iv_iron/paths.py
@@ -9,7 +9,7 @@ ARTIFACT_ROOT = Path(f"/share/costeffectiveness/artifacts/{metadata.PROJECT_NAME
 MODEL_SPEC_DIR = BASE_DIR / "model_specifications"
 RESULTS_ROOT = Path(f"/share/costeffectiveness/results/{metadata.PROJECT_NAME}/")
 
-# todo fix a better output location
-#CHILD_DATA_OUTPUT_DIR = RESULTS_ROOT / "child_data"
-CHILD_DATA_OUTPUT_DIR = Path("/Users/mkappel/viv_out") / "child_data"
+# TODO: find a better output location?
+CHILD_DATA_OUTPUT_DIR = RESULTS_ROOT / "child_data"
+
 


### PR DESCRIPTION
## Child outputs implementation for LBWSG

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-2995](https://jira.ihme.washington.edu/browse/MIC-2995)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_iv_iron/maternal_model/concept_model.html#simulation-output-table

*Changes*:
- Integrates upsteams workaround for two versions of VPH code in use for observers
- Enables all observers to be used
- Produces a CSV and HDF for child outputs with filenames of the form `location.scenario.input_draw.seed.[csv|hdf]`
- Makes the path for the output child data configurable in the model spec.

### Verification and Testing
Ran single `simulate run` to completion. Results were as expected, including the child output files.

