### PR TITLE
Incorporate shorter durations for other outcomes

### DIFF
--- a/src/vivarium_gates_iv_iron/constants/data_values.py
+++ b/src/vivarium_gates_iv_iron/constants/data_values.py
@@ -6,10 +6,12 @@ from vivarium_gates_iv_iron.constants import models
 
 
 class _Durations(NamedTuple):
-    FULL_TERM: float = 40 / 52
+    DETECTION: float = 6 / 52
     PARTIAL_TERM: float = 24 / 52
+    FULL_TERM: float = 40 / 52
     PREPOSTPARTUM: float = 1 / 52
     POSTPARTUM: float = 5 / 52
+
 
 
 DURATIONS = _Durations()


### PR DESCRIPTION
## Update pregnancy durations
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: feature
*JIRA issue*: [MIC-2970](https://jira.ihme.washington.edu/browse/MIC-2970)
[Research reference](https://github.com/ihmeuw/vivarium_research/pull/827)

Adds duration sampling conditional on pregnancy outcome.

NOTE: I think this will need an update to the birth recorder and
potentially to other observers.

### Verification and Testing
TODO
