### PR TITLE
Various YLD issues.

### DIFF
--- a/src/vivarium_gates_iv_iron/components/disability.py
+++ b/src/vivarium_gates_iv_iron/components/disability.py
@@ -23,20 +23,24 @@ class MaternalDisability:
             parameter_columns=['age', 'year'],
         )
 
-        self.anemia_disability = builder.value.get_value('anemia.disability_weight')
-        self.maternal_disability = builder.value.register_value_producer(
-            'maternal_disorders.disability_weight',
-            source=self.accrue_disability,
-            requires_columns=["alive", "pregnancy_status"],
-        )
+        self.raw_anemia_disability = builder.value.get_value('anemia.disability_weight')
 
-        builder.value.register_value_modifier(
-            "disability_weight",
-            self.maternal_disorders_disability,
+        builder.value.register_value_producer(
+            'maternal_disorders.disability_weight',
+            source=self.maternal_disorders_disability,
+            requires_columns=["alive", "pregnancy_status"],
+            requires_values=['anemia.disability_weight'],
         )
         builder.value.register_value_producer(
             "real_anemia.disability_weight",
             source=self.anemia_disability,
+            requires_columns=["alive", "pregnancy_status"],
+            requires_values=['anemia.disability_weight'],
+        )
+
+        builder.value.register_value_modifier(
+            "disability_weight",
+            self.accrue_disability,
         )
 
         self.population_view = builder.population.get_view(['alive', 'pregnancy_status'])
@@ -56,7 +60,7 @@ class MaternalDisability:
         return dw
 
     def accrue_disability(self, index: pd.Index):
-        anemia_disability_weight = self.anemia_disability(index)
+        anemia_disability_weight = self.raw_anemia_disability(index)
         maternal_disorder_ylds = self.ylds_per_maternal_disorder(index)
         maternal_disorder_disability_weight = (
             maternal_disorder_ylds * 365 / self.step_size().days

--- a/src/vivarium_gates_iv_iron/components/observers.py
+++ b/src/vivarium_gates_iv_iron/components/observers.py
@@ -11,6 +11,7 @@ from vivarium_public_health.metrics import (
     MortalityObserver as MortalityObserver_,
     ResultsStratifier as ResultsStratifier_,
 )
+from vivarium_public_health.metrics.stratification import Source, SourceType
 from vivarium_public_health.utilities import to_years
 
 from vivarium_gates_iv_iron.constants import data_values, models
@@ -20,6 +21,12 @@ class ResultsStratifier(ResultsStratifier_):
 
     def register_stratifications(self, builder: Builder) -> None:
         super().register_stratifications(builder)
+        self.setup_stratification(
+            builder,
+            name='pregnancy_status',
+            sources=[Source('pregnancy_status', SourceType.COLUMN)],
+            categories=models.PREGNANCY_MODEL_STATES,
+        )
 
 
 class MortalityObserver(MortalityObserver_):

--- a/src/vivarium_gates_iv_iron/constants/results.py
+++ b/src/vivarium_gates_iv_iron/constants/results.py
@@ -32,7 +32,7 @@ THROWAWAY_COLUMNS = [f"{state}_event_count" for state in models.STATES]
 TOTAL_POPULATION_COLUMN_TEMPLATE = "total_population_{POP_STATE}"
 DEATH_COLUMN_TEMPLATE = "death_due_to_{CAUSE_OF_DEATH}_year_{YEAR}_age_{AGE_GROUP}"
 YLLS_COLUMN_TEMPLATE = "ylls_due_to_{CAUSE_OF_DEATH}_year_{YEAR}_age_{AGE_GROUP}"
-YLDS_COLUMN_TEMPLATE = "ylds_due_to_{CAUSE_OF_DISABILITY}_year_{YEAR}_age_{AGE_GROUP}"
+YLDS_COLUMN_TEMPLATE = "ylds_due_to_{CAUSE_OF_DISABILITY}_year_{YEAR}_age_{AGE_GROUP}_pregnancy_status_{PREGNANCY_STATE}"
 PREGNANCY_OUTCOME_COUNT_COLUMN_TEMPLATE = "{PREGNANCY_OUTCOME}_count_year_{YEAR}_age_{AGE_GROUP}"
 PREGNANCY_STATE_PERSON_TIME_COLUMN_TEMPLATE = (
     "{PREGNANCY_STATE}_with_{PREGNANCY_OUTCOME}_with_{MATERNAL_HEMORRHAGE_STATE}_person_time_year_{YEAR}_age_{AGE_GROUP}"
@@ -92,7 +92,7 @@ CAUSES_OF_DEATH = (
     "other_causes",
     "maternal_disorders",
 )
-CAUSES_OF_DISABILITY = ("maternal_disorders",)
+CAUSES_OF_DISABILITY = ("maternal_disorders", "anemia")
 
 TEMPLATE_FIELD_MAP = {
     "POP_STATE": POP_STATES,

--- a/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/south_asia.yaml
@@ -44,3 +44,5 @@ configuration:
         default:
             - "year"
             - "age"
+        disability:
+            include: ['pregnancy_status']


### PR DESCRIPTION
## Fix various YLD issues
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: bugfix
*JIRA issue*: [MIC-3085](https://jira.ihme.washington.edu/browse/MIC-3085)
*Research reference*: https://github.com/ihmeuw/vivarium_research/pull/876

- No anemia ylds in outputs (results processing bug)
- Add yld stratification by pregnancy state
- Fix YLD attribution issue

### Verification and Testing
Manual run outputs:
```
 {'total_population': 10000,
 'total_population_tracked': 10000,
 'total_population_untracked': 0,
 'years_lived_with_disability': 292.88866335966395,
 'ylds_due_to_anemia_year_2022_pregnancy_status_maternal_disorder': 0.0,
 'ylds_due_to_anemia_year_2022_pregnancy_status_no_maternal_disorder': 0.0,
 'ylds_due_to_anemia_year_2022_pregnancy_status_not_pregnant': 191.4219301848049,
 'ylds_due_to_anemia_year_2022_pregnancy_status_postpartum': 1.0644763860369608,
 'ylds_due_to_anemia_year_2022_pregnancy_status_pregnant': 6.5647638603696095,
 'ylds_due_to_anemia_year_2023_pregnancy_status_maternal_disorder': 0.0,
 'ylds_due_to_anemia_year_2023_pregnancy_status_no_maternal_disorder': 0.0,
 'ylds_due_to_anemia_year_2023_pregnancy_status_not_pregnant': 80.572977412731,
 'ylds_due_to_anemia_year_2023_pregnancy_status_postpartum': 0.5067761806981519,
 'ylds_due_to_anemia_year_2023_pregnancy_status_pregnant': 3.6952772073921967,
 'ylds_due_to_maternal_disorders_year_2022_pregnancy_status_maternal_disorder': 3.9140577218211203,
 'ylds_due_to_maternal_disorders_year_2022_pregnancy_status_no_maternal_disorder': 0.0,
 'ylds_due_to_maternal_disorders_year_2022_pregnancy_status_not_pregnant': 0.0,
 'ylds_due_to_maternal_disorders_year_2022_pregnancy_status_postpartum': 0.0,
 'ylds_due_to_maternal_disorders_year_2022_pregnancy_status_pregnant': 0.0,
 'ylds_due_to_maternal_disorders_year_2023_pregnancy_status_maternal_disorder': 4.947933041429436,
 'ylds_due_to_maternal_disorders_year_2023_pregnancy_status_no_maternal_disorder': 0.0,
 'ylds_due_to_maternal_disorders_year_2023_pregnancy_status_not_pregnant': 0.0,
 'ylds_due_to_maternal_disorders_year_2023_pregnancy_status_postpartum': 0.0,
 'ylds_due_to_maternal_disorders_year_2023_pregnancy_status_pregnant': 0.0}
```



