### PR TITLE
Add performance tuning run configurations

### DIFF
--- a/src/vivarium_gates_iv_iron/components/pregnancy.py
+++ b/src/vivarium_gates_iv_iron/components/pregnancy.py
@@ -267,6 +267,10 @@ class Pregnancy:
         )
         newly_pregnant = not_pregnant.intersection(potentially_pregnant)
 
+        # If there are no new pregancies, return
+        if len(newly_pregnant) == 0:
+            return
+
         child_status = self.new_children(newly_pregnant)
         outcome, duration = self._sample_pregnancy_outcome_and_duration(
             newly_pregnant,

--- a/src/vivarium_gates_iv_iron/model_specifications/branches/child_only_scenarios.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/branches/child_only_scenarios.yaml
@@ -1,0 +1,11 @@
+input_draw_count: 66 
+random_seed_count: 200
+
+branches:
+  - intervention:
+      scenario:
+        - 'baseline'
+        - 'oral_iron'
+        - 'antenatal_iv_iron'
+        # - 'postpartum_iv_iron'
+        # - 'antenatal_and_postpartum_iv_iron'

--- a/src/vivarium_gates_iv_iron/model_specifications/branches/throttled_scenarios.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/branches/throttled_scenarios.yaml
@@ -1,0 +1,11 @@
+input_draw_count: 25 
+random_seed_count: 25
+
+branches:
+  - intervention:
+      scenario:
+        - 'baseline'
+        - 'oral_iron'
+        - 'antenatal_iv_iron'
+        - 'postpartum_iv_iron'
+        - 'antenatal_and_postpartum_iv_iron'

--- a/src/vivarium_gates_iv_iron/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_iv_iron/model_specifications/model_spec.yaml
@@ -34,7 +34,7 @@ configuration:
         random_seed: 0
     time:
         start:
-            year: 2020
+            year: 2024
             month: 1
             day: 1
         end:
@@ -48,6 +48,7 @@ configuration:
         age_end: 54
         include_sex: 'Female'
         pregnant_lactating_women: False
+        # exit_age: 56
     intervention:
         start_year: 2025
         scenario: 'antenatal_and_postpartum_iv_iron'


### PR DESCRIPTION
## Add performance tuning run configurations

### Description
- *Category*: other/misc - cluster run configurations
- *JIRA issue*: [MIC-3175](https://jira.ihme.washington.edu/browse/MIC-3175)
- *Research reference*: n/a

#### Changes
- Adds `branches/child_only_scenarios.yaml` for running scenarios optimized to produce only child inputs for the child simulation.
- Adds `branches/throttled_scenarios.yaml` for running at a reasonable footprint for cluster.
- Updates start year to 2024
- Mends a bug where the simulation would crash if no pregnancies happened on a single timestep. 

### Verification and Testing
Ran with these configurations successfully to produce results V&V'd by research team.

